### PR TITLE
update example

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -31,7 +31,7 @@ with Anaconda:
 * `numpy <http://numpy.org>`__ >= 1.8.0 \*
 * `openmatrix <https://pypi.python.org/pypi/OpenMatrix/0.2.3>`__ >= 0.2.2 \*\*\*
 * `orca <https://synthicity.github.io/orca/>`__ >= 1.1 \*\*\*
-* `pandas <http://pandas.pydata.org>`__ >= 0.13.1 \*
+* `pandas <http://pandas.pydata.org>`__ >= 0.18.0 \*
 * `pyyaml <http://pyyaml.org/wiki/PyYAML>`__ >= 3.0 \*
 * `tables <http://www.pytables.org/moin>`__ >= 3.1.0 \*
 * `toolz <http://toolz.readthedocs.org/en/latest/>`__ or

--- a/example/configs/settings.yaml
+++ b/example/configs/settings.yaml
@@ -5,7 +5,7 @@ urban_threshold: 4
 cbd_threshold: 2
 rural_threshold: 6
 
-households_sample_size: 10000
+households_sample_size: 1000
 grade_school_max_age: 14
 
 county_map:

--- a/example/simulation.py
+++ b/example/simulation.py
@@ -4,15 +4,12 @@ import pandas as pd
 import numpy as np
 import os
 
-#orca.add_injectable("store", pd.HDFStore(
-#        os.path.join("..", "activitysim", "defaults", "test", "test.h5"), "r"))
-#orca.add_injectable("nonmotskm_matrix", np.ones((1454, 1454)))
 
 orca.run(["school_location_simulate"])
 orca.run(["workplace_location_simulate"])
 print orca.get_table("persons").distance_to_work.describe()
 orca.run(["auto_ownership_simulate"])
-#orca.run(["cdap_simulate"])
+orca.run(["cdap_simulate"])
 orca.run(['mandatory_tour_frequency'])
 orca.get_table("mandatory_tours").tour_type.value_counts()
 orca.run(["mandatory_scheduling"])
@@ -21,3 +18,4 @@ orca.get_table("non_mandatory_tours").tour_type.value_counts()
 orca.run(["destination_choice"])
 orca.run(["non_mandatory_scheduling"])
 orca.run(['tour_mode_choice_simulate'])
+orca.run(['trip_mode_choice_simulate'])

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'numpy >= 1.8.0',
         'openmatrix >= 0.2.2',
         'orca >= 1.1',
-        'pandas >= 0.13.1',
+        'pandas >= 0.18.0',
         'pyyaml >= 3.0',
         'tables >= 3.1.0',
         'toolz >= 0.7',


### PR DESCRIPTION
update example to include trip mode choice running on tours table for eatout purpose only, turn on cdap model, and set household sample size to 1000 so cdap requires less than 16GB of RAM.  Also update required pandas version to 0.18.0 (#68)