### PR TITLE
add explicit getter to Skims

### DIFF
--- a/activitysim/defaults/tables/skims.py
+++ b/activitysim/defaults/tables/skims.py
@@ -22,22 +22,26 @@ def omx_file(data_dir):
 
 @orca.injectable()
 def distance_skim(skims):
-    return skims['DISTANCE']
+    # want the Skim
+    return skims.get_skim('DISTANCE')
 
 
 @orca.injectable()
 def sovam_skim(skims):
-    return skims[('SOV_TIME', 'AM')]
+    # want the Skim
+    return skims.get_skim(('SOV_TIME', 'AM'))
 
 
 @orca.injectable()
 def sovmd_skim(skims):
-    return skims[('SOV_TIME', 'MD')]
+    # want the Skim
+    return skims.get_skim(('SOV_TIME', 'MD'))
 
 
 @orca.injectable()
 def sovpm_skim(skims):
-    return skims[('SOV_TIME', 'PM')]
+    # want the Skim
+    return skims.get_skim(('SOV_TIME', 'PM'))
 
 
 @orca.injectable(cache=True)

--- a/activitysim/skim.py
+++ b/activitysim/skim.py
@@ -200,7 +200,26 @@ class Skims(object):
 
     def __getitem__(self, key):
         """
-        Get an available skim object
+        Get the (df implicit) lookup for an available skim object
+
+        Parameters
+        ----------
+        key : hashable
+             The key (identifier) for this skim object
+
+        Returns
+        -------
+        impedances: pd.Series
+            A Series of impedances which are elements of the Skim object and
+            with the same index as df
+        """
+        # FIXME - misleading and confusing that this getter is NOT symmetrical to __setitem__
+        # get_skim below is the symmetrical getter corresponding to __setitem__
+        return self.lookup(self.skims[key])
+
+    def get_skim(self, key):
+        """
+        Get an available skim object (not the lookup)
 
         Parameters
         ----------
@@ -212,7 +231,8 @@ class Skims(object):
         skim: Skim
              The skim object
         """
-        return self.lookup(self.skims[key])
+        # FIXME - misleading that this (and NOT __getitem__) is symmetrical to __setitem__ setter
+        return self.skims[key]
 
 
 class Skims3D(object):


### PR DESCRIPTION
This fixes a problem where `distance_skim` injectable (and similar functions like `sovam_skim`) were calling the Skims `__get_item__` getter thinking they were getting a Skim when they were really getting a Series because `__get_item__`  is not a symmetrical operation to `__set_item__` but instead calls `lookup`.