### PR TITLE
Chunked interaction simulate

### DIFF
--- a/activitysim/defaults/misc.py
+++ b/activitysim/defaults/misc.py
@@ -52,3 +52,8 @@ def cache_skim_key_values(settings, preload_3d_skims):
         return settings['time_periods']['labels']
     else:
         return None
+
+
+@orca.injectable(cache=True)
+def chunk_size(settings):
+    return settings.get('chunk_size', 0)

--- a/activitysim/defaults/models/destination.py
+++ b/activitysim/defaults/models/destination.py
@@ -21,7 +21,8 @@ def destination_choice(set_random_seed,
                        non_mandatory_tours_merged,
                        skims,
                        destination_choice_spec,
-                       destination_size_terms):
+                       destination_size_terms,
+                       chunk_size):
 
     """
     Given the tour generation from the above, each tour needs to have a
@@ -54,12 +55,13 @@ def destination_choice(set_random_seed,
 
         print "Running segment '%s' of size %d" % (name, len(segment))
 
-        choices, _ = asim.interaction_simulate(segment,
-                                               alternatives,
-                                               spec[[name]],
-                                               skims=skims,
-                                               locals_d=locals_d,
-                                               sample_size=50)
+        choices = asim.interaction_simulate(segment,
+                                            alternatives,
+                                            spec[[name]],
+                                            skims=skims,
+                                            locals_d=locals_d,
+                                            sample_size=50,
+                                            chunk_size=chunk_size)
 
         choices_list.append(choices)
 

--- a/activitysim/defaults/models/non_mandatory_tour_frequency.py
+++ b/activitysim/defaults/models/non_mandatory_tour_frequency.py
@@ -35,7 +35,8 @@ def tot_tours(non_mandatory_tour_frequency_alts):
 def non_mandatory_tour_frequency(set_random_seed,
                                  persons_merged,
                                  non_mandatory_tour_frequency_alts,
-                                 non_mandatory_tour_frequency_spec):
+                                 non_mandatory_tour_frequency_spec,
+                                 chunk_size):
 
     """
     This model predicts the frequency of making non-mandatory trips
@@ -57,13 +58,14 @@ def non_mandatory_tour_frequency(set_random_seed,
 
         print "Running segment '%s' of size %d" % (name, len(segment))
 
-        choices, _ = asim.interaction_simulate(
+        choices = asim.interaction_simulate(
             segment,
             non_mandatory_tour_frequency_alts.to_frame(),
             # notice that we pick the column for the
             # segment for each segment we run
             non_mandatory_tour_frequency_spec[[name]],
-            sample_size=50)
+            sample_size=50,
+            chunk_size=chunk_size)
 
         choices_list.append(choices)
 

--- a/activitysim/defaults/models/school_location.py
+++ b/activitysim/defaults/models/school_location.py
@@ -21,7 +21,8 @@ def school_location_simulate(set_random_seed,
                              persons_merged,
                              school_location_spec,
                              skims,
-                             destination_size_terms):
+                             destination_size_terms,
+                             chunk_size):
 
     """
     The school location model predicts the zones in which various people will
@@ -45,12 +46,13 @@ def school_location_simulate(set_random_seed,
 
         choosers_segment = choosers[choosers["is_" + school_type]]
 
-        choices, _ = asim.interaction_simulate(choosers_segment,
-                                               alternatives,
-                                               spec[[school_type]],
-                                               skims=skims,
-                                               locals_d=locals_d,
-                                               sample_size=50)
+        choices = asim.interaction_simulate(choosers_segment,
+                                            alternatives,
+                                            spec[[school_type]],
+                                            skims=skims,
+                                            locals_d=locals_d,
+                                            sample_size=50,
+                                            chunk_size=chunk_size)
         choices_list.append(choices)
 
     choices = pd.concat(choices_list)

--- a/activitysim/defaults/models/util/vectorize_tour_scheduling.py
+++ b/activitysim/defaults/models/util/vectorize_tour_scheduling.py
@@ -115,7 +115,7 @@ def vectorize_tour_scheduling(tours, alts, spec):
             previous_tour_by_personid,
             alts))
 
-        nth_choices, _ = asim.interaction_simulate(
+        nth_choices = asim.interaction_simulate(
             nth_tours,
             alts.copy(),
             spec,

--- a/activitysim/defaults/models/workplace_location.py
+++ b/activitysim/defaults/models/workplace_location.py
@@ -19,7 +19,8 @@ def workplace_location_simulate(set_random_seed,
                                 persons_merged,
                                 workplace_location_spec,
                                 skims,
-                                destination_size_terms):
+                                destination_size_terms,
+                                chunk_size):
 
     """
     The workplace location model predicts the zones in which various people will
@@ -39,12 +40,16 @@ def workplace_location_simulate(set_random_seed,
     # the skims will be available under the name "skims" for any @ expressions
     locals_d = {"skims": skims}
 
-    choices, _ = asim.interaction_simulate(choosers,
-                                           alternatives,
-                                           workplace_location_spec,
-                                           skims=skims,
-                                           locals_d=locals_d,
-                                           sample_size=50)
+    # FIXME - HACK - only include columns actually used in spec (which we pathologically know)
+    choosers = choosers[["income_segment", "TAZ", "mode_choice_logsums"]]
+
+    choices = asim.interaction_simulate(choosers,
+                                        alternatives,
+                                        workplace_location_spec,
+                                        skims=skims,
+                                        locals_d=locals_d,
+                                        sample_size=50,
+                                        chunk_size=chunk_size)
 
     choices = choices.reindex(persons_merged.index)
 

--- a/activitysim/mnl.py
+++ b/activitysim/mnl.py
@@ -112,8 +112,20 @@ def interaction_dataset(choosers, alternatives, sample_size=None):
     alts_sample = alternatives.take(sample)
     alts_sample['chooser_idx'] = np.repeat(choosers.index.values, sample_size)
 
+    # FIXME - log
+    # print "\n###################### interaction_dataset\n"
+    # print "\nalts_sample.shape=", alts_sample.info(), "\n"
+    # print "\nchoosers.shape=", choosers.info(), "\n"
+    # print "\n##### alts_sample\n", alts_sample.head(10)
+    # print "\n##### choosers\n", choosers.head(10)
+
     alts_sample = pd.merge(
         alts_sample, choosers, left_on='chooser_idx', right_index=True,
         suffixes=('', '_r'))
+
+    # FIXME - log
+    # print "\npost-merge alts_sample.shape=", alts_sample.info(), "\n"
+    # print "\n##### alts_sample\n", alts_sample.head(10)
+    # print "\n######################\n"
 
     return alts_sample

--- a/example/configs/settings.yaml
+++ b/example/configs/settings.yaml
@@ -6,6 +6,8 @@ store: mtc_asim.h5
 
 households_sample_size: 1000
 
+chunk_size: 10000
+
 # area_types less than this are considered urban
 urban_threshold: 4
 cbd_threshold: 2

--- a/sandbox/simulation.py
+++ b/sandbox/simulation.py
@@ -89,8 +89,8 @@ orca.add_injectable("set_random_seed", set_random_seed)
 # config = 'sandbox' or 'example'
 # data = 'test', 'example', or 'full'
 inject_settings(config='example',
-                data='full',
-                households_sample_size=20000,
+                data='example',
+                households_sample_size=1000,
                 preload_3d_skims=True)
 
 print "gc enabled:", gc.isenabled()

--- a/sandbox/simulation.py
+++ b/sandbox/simulation.py
@@ -76,6 +76,11 @@ def run_model(model_name):
     orca.run([model_name])
     print_memory_info('after %s' % model_name)
 
+pd.options.display.max_columns = 500
+pd.options.display.max_rows = 20
+
+print "max_rows", pd.options.display.max_rows
+print "max_columns", pd.options.display.max_columns
 
 #gc.set_debug(gc.DEBUG_STATS)
 
@@ -84,8 +89,8 @@ orca.add_injectable("set_random_seed", set_random_seed)
 # config = 'sandbox' or 'example'
 # data = 'test', 'example', or 'full'
 inject_settings(config='example',
-                data='example',
-                households_sample_size=1000,
+                data='full',
+                households_sample_size=20000,
                 preload_3d_skims=True)
 
 print "gc enabled:", gc.isenabled()

--- a/sandbox/simulation.py
+++ b/sandbox/simulation.py
@@ -32,7 +32,8 @@ CONFIGS_DIRS = {
 def inject_settings(config='sandbox',
                     data='test',
                     households_sample_size=1000,
-                    preload_3d_skims=True):
+                    preload_3d_skims=True,
+                    chunk_size = 0):
 
     assert config in  CONFIGS_DIRS.keys(), 'Unknown config dir %s' % config
     config_dir = CONFIGS_DIRS.get(config)
@@ -46,6 +47,7 @@ def inject_settings(config='sandbox',
         settings = yaml.load(f)
         settings['households_sample_size'] = households_sample_size
         settings['preload_3d_skims'] = preload_3d_skims
+        settings['chunk_size'] = chunk_size
     orca.add_injectable("settings", settings)
 
 
@@ -66,6 +68,7 @@ def print_settings():
     print "configs_dir:", orca.get_injectable('configs_dir')
     print "households_sample_size =", orca.get_injectable('settings')['households_sample_size']
     print "preload_3d_skims = ", orca.get_injectable('preload_3d_skims')
+    print "chunk_size = ", orca.get_injectable('chunk_size')
 
 
 def set_random_seed():
@@ -91,7 +94,8 @@ orca.add_injectable("set_random_seed", set_random_seed)
 inject_settings(config='example',
                 data='example',
                 households_sample_size=1000,
-                preload_3d_skims=True)
+                preload_3d_skims=True,
+                chunk_size = 500)
 
 print "gc enabled:", gc.isenabled()
 print "gc get_threshold:", gc.get_threshold()


### PR DESCRIPTION
Chunking of interaction_simulate is enabled in settings file. Behavior unchanged from previous version if no chunking.

Different chunk_size values can result in minor variations in results from runs with other chunk sizes due to different array lengths passed to mnl.make_choices. This means that we can't do regression tests between runs with different chunk sizes. I am not sure this is a big deal...