### PR TITLE
add hh_chunking to cdap and vanilla chunking to vectorize_tour_schedu…

### DIFF
--- a/activitysim/activitysim.py
+++ b/activitysim/activitysim.py
@@ -220,9 +220,9 @@ def simple_simulate(choosers, spec, skims=None, locals_d=None):
 def chunked_choosers(choosers, chunk_size):
     # generator to iterate over chooses in chunk_size chunks
     chunk_size = int(chunk_size)
-    last_chooser = len(choosers.index) - 1
+    num_choosers = len(choosers.index)
     i = 0
-    while i < last_chooser:
+    while i < num_choosers:
         yield i, choosers[i: i+chunk_size]
         i += chunk_size
 
@@ -257,6 +257,8 @@ def interaction_simulate(
     # if necessary, could append to hdf5 store on disk:
     # http://pandas.pydata.org/pandas-docs/stable/io.html#id2
     choices = pd.concat(choices_list)
+
+    assert len(choices.index == len(choosers.index))
 
     return choices
 

--- a/activitysim/defaults/misc.py
+++ b/activitysim/defaults/misc.py
@@ -57,3 +57,11 @@ def cache_skim_key_values(settings, preload_3d_skims):
 @orca.injectable(cache=True)
 def chunk_size(settings):
     return settings.get('chunk_size', 0)
+
+
+@orca.injectable(cache=True)
+def hh_chunk_size(settings):
+    if 'hh_chunk_size' in settings:
+        return settings.get('hh_chunk_size', 0)
+    else:
+        return settings.get('chunk_size', 0)

--- a/activitysim/defaults/models/cdap.py
+++ b/activitysim/defaults/models/cdap.py
@@ -43,7 +43,7 @@ def cdap_all_people(configs_dir):
 @orca.step()
 def cdap_simulate(set_random_seed, persons_merged,
                   cdap_1_person_spec, cdap_2_person_spec, cdap_3_person_spec,
-                  cdap_final_rules, cdap_all_people):
+                  cdap_final_rules, cdap_all_people, hh_chunk_size):
     """
     CDAP stands for Coordinated Daily Activity Pattern, which is a choice of
     high-level activity pattern for each person, in a coordinated way with other
@@ -61,7 +61,10 @@ def cdap_simulate(set_random_seed, persons_merged,
                             cdap_2_person_spec,
                             cdap_3_person_spec,
                             cdap_final_rules,
-                            cdap_all_people)
+                            cdap_all_people,
+                            hh_chunk_size)
+
+    choices = choices.reindex(persons_merged.index)
 
     print "Choices:\n", choices.value_counts()
     orca.add_column("persons", "cdap_activity", choices)

--- a/activitysim/defaults/models/destination.py
+++ b/activitysim/defaults/models/destination.py
@@ -41,6 +41,8 @@ def destination_choice(set_random_seed,
     # the skims will be available under the name "skims" for any @ expressions
     locals_d = {"skims": skims}
 
+    print "destination_choice choosers:", len(choosers.index)
+
     choices_list = []
     # segment by trip type and pick the right spec for each person type
     for name, segment in choosers.groupby('tour_type'):
@@ -66,6 +68,9 @@ def destination_choice(set_random_seed,
         choices_list.append(choices)
 
     choices = pd.concat(choices_list)
+
+    # FIXME - can there be null destinations?
+    assert choices.isnull().sum() == 0
 
     print "Choices:\n", choices.describe()
     # every trip now has a destination which is the index from the

--- a/activitysim/defaults/models/mandatory_scheduling.py
+++ b/activitysim/defaults/models/mandatory_scheduling.py
@@ -46,7 +46,8 @@ def mandatory_scheduling(set_random_seed,
                          mandatory_tours_merged,
                          tdd_alts,
                          tdd_school_spec,
-                         tdd_work_spec):
+                         tdd_work_spec,
+                         chunk_size):
     """
     This model predicts the departure time and duration of each activity for
     mandatory tours
@@ -60,14 +61,14 @@ def mandatory_scheduling(set_random_seed,
 
     print "Running %d school tour scheduling choices" % len(school_tours)
 
-    school_choices = vectorize_tour_scheduling(school_tours, alts, school_spec)
+    school_choices = vectorize_tour_scheduling(school_tours, alts, school_spec, chunk_size)
 
     work_spec = tdd_work_spec.to_frame()
     work_tours = tours[tours.tour_type == "work"]
 
     print "Running %d work tour scheduling choices" % len(work_tours)
 
-    work_choices = vectorize_tour_scheduling(work_tours, alts, work_spec)
+    work_choices = vectorize_tour_scheduling(work_tours, alts, work_spec, chunk_size)
 
     choices = pd.concat([school_choices, work_choices])
 

--- a/activitysim/defaults/models/non_mandatory_scheduling.py
+++ b/activitysim/defaults/models/non_mandatory_scheduling.py
@@ -21,7 +21,8 @@ def tdd_non_mandatory_spec(configs_dir):
 def non_mandatory_scheduling(set_random_seed,
                              non_mandatory_tours_merged,
                              tdd_alts,
-                             tdd_non_mandatory_spec):
+                             tdd_non_mandatory_spec,
+                             chunk_size):
     """
     This model predicts the departure time and duration of each activity for
     non-mandatory tours
@@ -34,7 +35,7 @@ def non_mandatory_scheduling(set_random_seed,
     spec = tdd_non_mandatory_spec.to_frame()
     alts = tdd_alts.to_frame()
 
-    choices = vectorize_tour_scheduling(tours, alts, spec)
+    choices = vectorize_tour_scheduling(tours, alts, spec, chunk_size)
 
     print "Choices:\n", choices.describe()
 

--- a/activitysim/defaults/models/non_mandatory_tour_frequency.py
+++ b/activitysim/defaults/models/non_mandatory_tour_frequency.py
@@ -40,7 +40,7 @@ def non_mandatory_tour_frequency(set_random_seed,
 
     """
     This model predicts the frequency of making non-mandatory trips
-    (alternatives for this model come from a seaparate csv file which is
+    (alternatives for this model come from a separate csv file which is
     configured by the user) - these trips include escort, shopping, othmaint,
     othdiscr, eatout, and social trips in various combination.
     """
@@ -73,6 +73,7 @@ def non_mandatory_tour_frequency(set_random_seed,
 
     print "Choices:\n", choices.value_counts()
 
+    # FIXME - no need to reindex?
     orca.add_column("persons", "non_mandatory_tour_frequency", choices)
 
     add_dependent_columns("persons", "persons_nmtf")

--- a/activitysim/defaults/models/util/vectorize_tour_scheduling.py
+++ b/activitysim/defaults/models/util/vectorize_tour_scheduling.py
@@ -45,7 +45,7 @@ def get_previous_tour_by_tourid(current_tour_person_ids,
     return previous_tour_by_tourid
 
 
-def vectorize_tour_scheduling(tours, alts, spec):
+def vectorize_tour_scheduling(tours, alts, spec, chunk_size=0):
     """
     The purpose of this method is fairly straightforward - it takes tours
     and schedules them into time slots.  Alternatives should be specified so
@@ -119,7 +119,8 @@ def vectorize_tour_scheduling(tours, alts, spec):
             nth_tours,
             alts.copy(),
             spec,
-            sample_size=min(len(alts), 50)
+            sample_size=min(len(alts), 50),
+            chunk_size=chunk_size
         )
 
         choices.append(nth_choices)

--- a/activitysim/defaults/models/workplace_location.py
+++ b/activitysim/defaults/models/workplace_location.py
@@ -51,6 +51,7 @@ def workplace_location_simulate(set_random_seed,
                                         sample_size=50,
                                         chunk_size=chunk_size)
 
+    # FIXME - no need to reindex?
     choices = choices.reindex(persons_merged.index)
 
     print "Describe of choices:\n", choices.describe()

--- a/activitysim/defaults/tables/households.py
+++ b/activitysim/defaults/tables/households.py
@@ -25,6 +25,18 @@ def households(set_random_seed, store, settings):
     return store["households"]
 
 
+# this assigns a chunk_id to each household based on the chunk_size setting
+@orca.column("households", cache=True)
+def chunk_id(households, hh_chunk_size):
+
+    chunk_ids = pd.Series(range(len(households)), households.index)
+
+    if hh_chunk_size > 0:
+        chunk_ids = np.floor(chunk_ids.div(hh_chunk_size)).astype(int)
+
+    return chunk_ids
+
+
 # this is a placeholder table for columns that get computed after the
 # auto ownership model
 @orca.table()

--- a/activitysim/defaults/test/test_defaults.py
+++ b/activitysim/defaults/test/test_defaults.py
@@ -190,4 +190,4 @@ def test_full_run_with_chunks(store, omx_file):
     tour_count = full_run(store, omx_file, preload_3d_skims=True, chunk_size=10)
 
     # FIXME - different sampling causes slightly different results?
-    assert(tour_count == 181)
+    assert(tour_count == 187)

--- a/sandbox/simulation.py
+++ b/sandbox/simulation.py
@@ -12,6 +12,7 @@ import pandas as pd
 from activitysim import defaults
 from activitysim import activitysim as asim
 
+print "np.geterr()", np.geterr()
 
 # you will want to configure this with the locations of the canonical datasets
 DATA_REPO = os.path.join(os.path.dirname(__file__), '..', '..', 'activitysim-data')
@@ -33,7 +34,8 @@ def inject_settings(config='sandbox',
                     data='test',
                     households_sample_size=1000,
                     preload_3d_skims=True,
-                    chunk_size = 0):
+                    chunk_size = 0,
+                    hh_chunk_size = 0):
 
     assert config in  CONFIGS_DIRS.keys(), 'Unknown config dir %s' % config
     config_dir = CONFIGS_DIRS.get(config)
@@ -48,6 +50,7 @@ def inject_settings(config='sandbox',
         settings['households_sample_size'] = households_sample_size
         settings['preload_3d_skims'] = preload_3d_skims
         settings['chunk_size'] = chunk_size
+        settings['hh_chunk_size'] = hh_chunk_size
     orca.add_injectable("settings", settings)
 
 
@@ -69,6 +72,7 @@ def print_settings():
     print "households_sample_size =", orca.get_injectable('settings')['households_sample_size']
     print "preload_3d_skims = ", orca.get_injectable('preload_3d_skims')
     print "chunk_size = ", orca.get_injectable('chunk_size')
+    print "hh_chunk_size = ", orca.get_injectable('hh_chunk_size')
 
 
 def set_random_seed():
@@ -91,11 +95,19 @@ orca.add_injectable("set_random_seed", set_random_seed)
 
 # config = 'sandbox' or 'example'
 # data = 'test', 'example', or 'full'
+# inject_settings(config='example',
+#                 data='full',
+#                 households_sample_size=20000,
+#                 preload_3d_skims=True,
+#                 chunk_size = 10000,
+#                 hh_chunk_size = 10000)
+
 inject_settings(config='example',
                 data='example',
                 households_sample_size=1000,
                 preload_3d_skims=True,
-                chunk_size = 500)
+                chunk_size = 1000,
+                hh_chunk_size = 1000)
 
 print "gc enabled:", gc.isenabled()
 print "gc get_threshold:", gc.get_threshold()


### PR DESCRIPTION
Added chunking by households to CDAP. Because CDAP coordinates activities by working on persons grouped by households, processing the population in batches (or chunks) requires ensuring that all persons in a household are included in the same chunk.

Added chunking arguments to interaction_simulate calls in mandatory_tour_frequency and non_mandatory_tour_frequency.

We may eventually be able to consolidate hh_chunk_size and chunk_size settings, but I am keeping them separate for now to facilitate performance testing.

Changed utils_to_probs in mnl.py to prevent inf probabilities when all utilities are large negative numbers.  Also added warning reports to make_choices to raise error of probabilities don't sum to approximately 1.0. We need to do more in this area but we have an issue open concerning that.