### PR TITLE
add temp targets to accessibility trace

### DIFF
--- a/activitysim/defaults/test/test_defaults.py
+++ b/activitysim/defaults/test/test_defaults.py
@@ -250,6 +250,6 @@ def test_full_run_with_hh_trace(store, omx_file):
     # should have created accessibility csv trace file
     a = pd.read_csv(accessibility_fname)
     assert a.iloc[1][0] == 'dest'
-    assert a.iloc[1][1] == OD[1]
+    assert int(a.iloc[1][1]) == OD[1]
     assert a.iloc[2][0] == 'orig'
-    assert a.iloc[2][1] == OD[0]
+    assert int(a.iloc[2][1]) == OD[0]

--- a/activitysim/tests/data/sample_assignment_spec.csv
+++ b/activitysim/tests/data/sample_assignment_spec.csv
@@ -1,8 +1,12 @@
 Description,Target,Expression
 # a comment line
+# _temp = 8, 9, 9
 a temp variable,_temp,CONSTANT+df.thing1
 a scalar temp,_scalar,42
 # assignments
-assign to target,target1,df.thing1 == 1
+assign to target,target1,df.thing1 == _shadow
+overwrites locals_d,_shadow,1
+assign to target,target1,df.thing1 == _shadow
+# 3,2,4 + 8,9,9 + 42 = 53, 52, 55
 assign temp to target,target2,df.thing2 + _temp + _scalar - df.thing1
 this should fail,target3,undefined_variable + 3

--- a/activitysim/tests/test_asim_eval.py
+++ b/activitysim/tests/test_asim_eval.py
@@ -30,7 +30,7 @@ def test_read_model_spec(spec_name):
 
     spec = asim_eval.read_assignment_spec(spec_name)
 
-    assert len(spec) == 5
+    assert len(spec) == 7
 
     assert list(spec.columns) == ['description', 'target', 'expression']
 
@@ -39,12 +39,33 @@ def test_eval_variables(capsys, spec_name, data):
 
     spec = asim_eval.read_assignment_spec(spec_name)
 
-    locals_d = {'CONSTANT': 7}
-    result = asim_eval.assign_variables(spec, data, locals_d)
+    locals_d = {'CONSTANT': 7, '_shadow': 99}
 
-    print result
+    trace_rows = None
+    results, trace_results = asim_eval.assign_variables(spec, data, locals_d, trace_rows)
 
-    assert list(result.columns) == ['target3', 'target2', 'target1']
-    assert list(result.target1) == [True, False, False]
-    assert list(result.target2) == [53, 53, 55]
-    assert list(result.target3) == [None, None, None]
+    print results
+
+    assert list(results.columns) == ['target1', 'target2', 'target3']
+    assert list(results.target1) == [True, False, False]
+    assert list(results.target2) == [53, 53, 55]
+    assert list(results.target3) == [None, None, None]
+    assert trace_results is None
+
+    trace_rows = [False, True, False]
+
+    results, trace_results = asim_eval.assign_variables(spec, data, locals_d, trace_rows=trace_rows)
+
+    print trace_results
+
+    assert trace_results is not None
+    assert '_scalar' in trace_results.columns
+    assert list(trace_results['_scalar']) == [42]
+
+    # shadow should have been assigned
+    assert list(trace_results['_shadow']) == [1]
+    assert list(trace_results['_temp']) == [9]
+
+    assert locals_d['_shadow'] == 99
+
+    out, err = capsys.readouterr()

--- a/sandbox/simulation.py
+++ b/sandbox/simulation.py
@@ -120,8 +120,8 @@ orca.add_injectable("set_random_seed", set_random_seed)
 #                 hh_chunk_size = 50000)
 
 inject_settings(config='sandbox',
-                data='example',
-                households_sample_size=5000,
+                data='test',
+                households_sample_size=50,
                 preload_3d_skims=True,
                 chunk_size = 0,
                 hh_chunk_size = 0)


### PR DESCRIPTION
accessibility tool now writes temp targets to accessibility.csv, as well as the assigned targets, to aid debugging .