### PR TITLE
Raise zero probs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,11 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda update -q conda
 - conda info -a
+# FIXME - openmatrix is broken with pytables 3.3.0
 - |
-  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cytoolz numpy pandas pip pytables pyyaml
+  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cytoolz numpy pandas pip pytables=3.2.3.1 pyyaml
 - source activate test-environment
 - pip install orca openmatrix zbox
-# FIXME - openmatrix is broken with pytables 3.3.0
-- pip install 'tables>= 3.1.0,<3.3.0'
 - pip install pytest pytest-cov coveralls pep8 pytest-xdist
 - pip install sphinx numpydoc
 - pip install psutil

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ install:
   conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cytoolz numpy pandas pip pytables pyyaml
 - source activate test-environment
 - pip install orca openmatrix zbox
+# FIXME - openmatrix is broken with pytables 3.3.0
+- pip install 'tables>= 3.1.0,<3.3.0'
 - pip install pytest pytest-cov coveralls pep8 pytest-xdist
 - pip install sphinx numpydoc
 - pip install psutil

--- a/activitysim/activitysim.py
+++ b/activitysim/activitysim.py
@@ -344,10 +344,12 @@ def eval_mnl(choosers, spec, locals_d=None, trace_label=None, trace_choice_name=
     """
 
     trace_label = tracing.extend_trace_label(trace_label, 'mnl')
+    check_for_variability = tracing.check_for_variability()
 
     model_design = eval_variables(spec.index, choosers, locals_d)
 
-    _check_for_variability(model_design, trace_label)
+    if check_for_variability:
+        _check_for_variability(model_design, trace_label)
 
     # matrix product of spec expression evals with utility coefficients of alternatives
     # sums the partial utilities (represented by each spec row) of the alternatives
@@ -407,11 +409,13 @@ def eval_nl(choosers, spec, nest_spec, locals_d=None, trace_label=None, trace_ch
     """
 
     trace_label = tracing.extend_trace_label(trace_label, 'nl')
+    check_for_variability = tracing.check_for_variability()
 
     # column names of model_design match spec index values
     model_design = eval_variables(spec.index, choosers, locals_d)
 
-    _check_for_variability(model_design, trace_label)
+    if check_for_variability:
+        _check_for_variability(model_design, trace_label)
 
     # raw utilities of all the leaves
 
@@ -529,7 +533,7 @@ def simple_simulate(choosers, spec, nest_spec, skims=None, locals_d=None,
     return choices
 
 
-def eval_interaction_utilities(spec, df, locals_d, trace_label, trace_rows, check_variability=True):
+def eval_interaction_utilities(spec, df, locals_d, trace_label, trace_rows):
     """
     Compute the utilities for a single-alternative spec evaluated in the context of df
 
@@ -587,6 +591,8 @@ def eval_interaction_utilities(spec, df, locals_d, trace_label, trace_rows, chec
     else:
         trace_eval_results = None
 
+    check_for_variability = tracing.check_for_variability()
+
     # need to be able to identify which variables causes an error, which keeps
     # this from being expressed more parsimoniously
 
@@ -601,12 +607,12 @@ def eval_interaction_utilities(spec, df, locals_d, trace_label, trace_rows, chec
             else:
                 v = df.eval(expr)
 
-            if check_variability and v.std() == 0:
+            if check_for_variability and v.std() == 0:
                 logger.info("%s: no variability (%s) in: %s" % (trace_label, v.iloc[0], expr))
                 no_variability += 1
 
             # FIXME - how likely is this to happen? Not sure it is really a problem?
-            if check_variability and np.count_nonzero(v.isnull().values) > 0:
+            if check_for_variability and np.count_nonzero(v.isnull().values) > 0:
                 logger.info("%s: missing values in: %s" % (trace_label, expr))
                 has_missing_vals += 1
 

--- a/activitysim/asim_eval.py
+++ b/activitysim/asim_eval.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 import pandas as pd
 
-logger = logging.getLogger('activitysim')
+logger = logging.getLogger(__name__)
 
 
 def undupe_column_names(df, template="{} ({})"):

--- a/activitysim/cdap/cdap.py
+++ b/activitysim/cdap/cdap.py
@@ -4,7 +4,6 @@
 import logging
 import itertools
 
-
 import numpy as np
 import pandas as pd
 from zbox import toolz as tz, gen
@@ -15,7 +14,6 @@ from .. import nl
 
 from .. import tracing
 from ..tracing import print_elapsed_time
-
 
 logger = logging.getLogger(__name__)
 
@@ -928,10 +926,9 @@ def run_cdap(
     # segment by person type and pick the right spec for each person type
     for i, persons_chunk in hh_chunked_choosers(persons):
 
-        logger.info("run_cdap running hh_chunk = %s with %d persons"
-                    % (i, len(persons_chunk)))
+        logger.info("Running chunk %s of with %d persons" % (i, len(persons_chunk)))
 
-        chunk_trace_label = tracing.extend_trace_label(trace_label, '.chunk_%s' % i)
+        chunk_trace_label = tracing.extend_trace_label(trace_label, 'chunk_%s' % i)
 
         choices = _run_cdap(persons_chunk,
                             cdap_indiv_spec,

--- a/activitysim/cdap/cdap.py
+++ b/activitysim/cdap/cdap.py
@@ -913,7 +913,7 @@ def run_cdap(
             'extra' household members activities are assigned by cdap_fixed_relative_proportions
     """
 
-    trace_label = (trace_label or 'cdap')
+    trace_label = tracing.extend_trace_label(trace_label, 'cdap')
 
     if (chunk_size == 0) or (chunk_size >= len(persons.index)):
         choices = _run_cdap(persons,
@@ -931,7 +931,7 @@ def run_cdap(
         logger.info("run_cdap running hh_chunk = %s with %d persons"
                     % (i, len(persons_chunk)))
 
-        chunk_trace_label = "%s.chunk_%s" % (trace_label, i)
+        chunk_trace_label = tracing.extend_trace_label(trace_label, '.chunk_%s' % i)
 
         choices = _run_cdap(persons_chunk,
                             cdap_indiv_spec,

--- a/activitysim/defaults/misc.py
+++ b/activitysim/defaults/misc.py
@@ -92,6 +92,11 @@ def hh_chunk_size(settings):
 
 
 @orca.injectable(cache=True)
+def check_for_variability(settings):
+    return bool(settings.get('check_for_variability', False))
+
+
+@orca.injectable(cache=True)
 def trace_hh_id(settings):
 
     id = settings.get('trace_hh_id', None)

--- a/activitysim/defaults/misc.py
+++ b/activitysim/defaults/misc.py
@@ -85,10 +85,8 @@ def chunk_size(settings):
 
 @orca.injectable(cache=True)
 def hh_chunk_size(settings):
-    if 'hh_chunk_size' in settings:
-        return int(settings.get('hh_chunk_size', 0))
-    else:
-        return int(settings.get('chunk_size', 0))
+    # if hh_chunk_size set nonzero, use it, otherwise fall back to chunk_size
+    return int(settings.get('hh_chunk_size', 0)) or int(settings.get('chunk_size', 0))
 
 
 @orca.injectable(cache=True)

--- a/activitysim/defaults/models/accessibility.py
+++ b/activitysim/defaults/models/accessibility.py
@@ -14,6 +14,9 @@ from activitysim import tracing
 from .util.misc import read_model_settings, get_model_constants
 
 
+logger = logging.getLogger(__name__)
+
+
 class AccessibilitySkims(object):
     """
     Wrapper for skim arrays to facilitate use of skims by accessibility model
@@ -49,8 +52,7 @@ class AccessibilitySkims(object):
             data = self.skims.get_skim(key).data
         except KeyError:
             omx_key = '__'.join(key)
-            tracing.info(__name__,
-                         message="AccessibilitySkims loading %s from omx as %s" % (key, omx_key,))
+            logger.info("AccessibilitySkims loading %s from omx as %s" % (key, omx_key,))
             data = self.omx[omx_key]
 
         data = data[:self.length, :self.length]
@@ -98,8 +100,7 @@ def compute_accessibility(settings, accessibility_spec,
     steeper than automobile or transit.  The minimum accessibility is zero.
     """
 
-    tracing.info(__name__,
-                 "Running compute_accessibility")
+    logger.info("Running compute_accessibility")
 
     constants = get_model_constants(accessibility_settings)
     land_use_columns = accessibility_settings.get('land_use_columns', [])
@@ -148,8 +149,7 @@ def compute_accessibility(settings, accessibility_spec,
     if trace_od:
 
         if not trace_od_rows.any():
-            tracing.warn(__name__,
-                         "trace_od not found origin = %s, dest = %s" % (trace_orig, trace_dest))
+            logger.warn("trace_od not found origin = %s, dest = %s" % (trace_orig, trace_dest))
         else:
 
             # add OD columns to trace results

--- a/activitysim/defaults/models/auto_ownership.py
+++ b/activitysim/defaults/models/auto_ownership.py
@@ -2,6 +2,7 @@
 # See full license in LICENSE.txt.
 
 import os
+import logging
 
 import orca
 
@@ -9,6 +10,9 @@ from activitysim import activitysim as asim
 from activitysim import tracing
 from .util.misc import add_dependent_columns
 from .util.misc import read_model_settings, get_logit_model_settings, get_model_constants
+
+
+logger = logging.getLogger(__name__)
 
 
 @orca.injectable()
@@ -32,8 +36,7 @@ def auto_ownership_simulate(set_random_seed, households_merged,
     with given characteristics owns
     """
 
-    tracing.info(__name__,
-                 "Running auto_ownership_simulate with %d households" % len(households_merged))
+    logger.info("Running auto_ownership_simulate with %d households" % len(households_merged))
 
     nest_spec = get_logit_model_settings(auto_ownership_settings)
     constants = get_model_constants(auto_ownership_settings)

--- a/activitysim/defaults/models/cdap.py
+++ b/activitysim/defaults/models/cdap.py
@@ -1,6 +1,7 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+import logging
 import os
 
 import orca
@@ -11,6 +12,9 @@ from activitysim import tracing
 
 from .util.misc import read_model_settings, get_model_constants
 from activitysim.cdap import cdap
+
+
+logger = logging.getLogger(__name__)
 
 
 @orca.injectable()
@@ -79,8 +83,7 @@ def cdap_simulate(persons_merged,
 
     constants = get_model_constants(cdap_settings)
 
-    tracing.info(__name__,
-                 "Running cdap_simulate with %d persons" % len(persons_df.index))
+    logger.info("Running cdap_simulate with %d persons" % len(persons_df.index))
 
     choices = cdap.run_cdap(persons=persons_df,
                             cdap_indiv_spec=cdap_indiv_spec,

--- a/activitysim/defaults/models/destination.py
+++ b/activitysim/defaults/models/destination.py
@@ -65,8 +65,7 @@ def destination_choice(set_random_seed,
     if constants is not None:
         locals_d.update(constants)
 
-    tracing.info(__name__,
-                 "Running destination_choice  with %d non_mandatory_tours" % len(choosers.index))
+    logger.info("Running destination_choice  with %d non_mandatory_tours" % len(choosers.index))
 
     choices_list = []
     # segment by trip type and pick the right spec for each person type
@@ -75,14 +74,13 @@ def destination_choice(set_random_seed,
         # FIXME - there are two options here escort with kids and without
         kludge_name = name
         if name == "escort":
-            tracing.error(__name__,
-                          "destination_choice escort not implemented - running shopping instead")
+            logging.error("destination_choice escort not implemented - running shopping instead")
             kludge_name = "shopping"
 
         # the segment is now available to switch between size terms
         locals_d['segment'] = kludge_name
 
-        tracing.info(__name__, "Running segment '%s' of size %d" % (name, len(segment)))
+        logger.info("Running segment '%s' of size %d" % (name, len(segment)))
 
         # name index so tracing knows how to slice
         segment.index.name = 'tour_id'
@@ -129,7 +127,7 @@ def patch_mandatory_tour_destination(mandatory_tours_merged, trace_hh_id):
     table can use destination for any tour type.
     """
 
-    tracing.info(__name__, "Running patch_mandatory_tour_destination")
+    logger.info("Running patch_mandatory_tour_destination")
 
     mandatory_tours_merged['destination'] = \
         np.where(mandatory_tours_merged['tour_type'] == 'school',

--- a/activitysim/defaults/models/mandatory_scheduling.py
+++ b/activitysim/defaults/models/mandatory_scheduling.py
@@ -75,8 +75,7 @@ def mandatory_scheduling(set_random_seed,
     school_spec = tdd_school_spec.to_frame()
     school_tours = tours[tours.tour_type == "school"]
 
-    tracing.info(__name__,
-                 "Running mandatory_scheduling school_tours with %d tours" % len(school_tours))
+    logger.info("Running mandatory_scheduling school_tours with %d tours" % len(school_tours))
 
     school_choices = vectorize_tour_scheduling(
         school_tours, alts, school_spec, constants, chunk_size,
@@ -85,7 +84,7 @@ def mandatory_scheduling(set_random_seed,
     work_spec = tdd_work_spec.to_frame()
     work_tours = tours[tours.tour_type == "work"]
 
-    tracing.info(__name__, "Running %d work tour scheduling choices" % len(work_tours))
+    logger.info("Running %d work tour scheduling choices" % len(work_tours))
 
     work_choices = vectorize_tour_scheduling(
         work_tours, alts, work_spec, constants, chunk_size,

--- a/activitysim/defaults/models/mandatory_tour_frequency.py
+++ b/activitysim/defaults/models/mandatory_tour_frequency.py
@@ -42,8 +42,7 @@ def mandatory_tour_frequency(set_random_seed,
     choosers = persons_merged.to_frame()
     # filter based on results of CDAP
     choosers = choosers[choosers.cdap_activity == 'M']
-    tracing.info(__name__,
-                 "Running mandatory_tour_frequency with %d persons" % len(choosers))
+    logger.info("Running mandatory_tour_frequency with %d persons" % len(choosers))
 
     nest_spec = get_logit_model_settings(mandatory_tour_frequency_settings)
     constants = get_model_constants(mandatory_tour_frequency_settings)

--- a/activitysim/defaults/models/mode.py
+++ b/activitysim/defaults/models/mode.py
@@ -172,8 +172,7 @@ def tour_mode_choice_simulate(tours_merged,
     if trace_hh_id:
         tracing.register_tours(tours, trace_hh_id)
 
-    tracing.info(__name__,
-                 "Running tour_mode_choice_simulate with %d tours" % len(tours.index))
+    logger.info("Running tour_mode_choice_simulate with %d tours" % len(tours.index))
 
     tracing.print_summary('tour_mode_choice_simulate tour_type',
                           tours.tour_type, value_counts=True)
@@ -197,9 +196,8 @@ def tour_mode_choice_simulate(tours_merged,
         # name index so tracing knows how to slice
         segment.index.name = 'tour_id'
 
-        tracing.info(__name__,
-                     "tour_mode_choice_simulate running %s tour_type '%s'" %
-                     (len(segment.index), tour_type, ))
+        logger.info("tour_mode_choice_simulate running %s tour_type '%s'" %
+                    (len(segment.index), tour_type, ))
 
         # FIXME - check that destination is not null (patch_mandatory_tour_destination not run?)
 
@@ -260,20 +258,20 @@ def trip_mode_choice_simulate(tours_merged,
                               trace_hh_id):
 
     # FIXME - running the trips model on tours
-    tracing.error(__name__, 'trips not implemented running the trips model on tours')
+    logging.error('trips not implemented running the trips model on tours')
 
     trips = tours_merged.to_frame()
 
     nest_spec = get_logit_model_settings(trip_mode_choice_settings)
     constants = get_model_constants(trip_mode_choice_settings)
 
-    tracing.info(__name__, "Running trip_mode_choice_simulate with %d trips" % len(trips))
+    logger.info("Running trip_mode_choice_simulate with %d trips" % len(trips))
 
     choices_list = []
 
     for tour_type, segment in trips.groupby('tour_type'):
 
-        tracing.info(__name__, "running %s tour_type '%s'" % (len(segment.index), tour_type, ))
+        logger.info("running %s tour_type '%s'" % (len(segment.index), tour_type, ))
 
         orig_key = 'TAZ'
         dest_key = 'destination'
@@ -320,7 +318,7 @@ def trip_mode_choice_simulate(tours_merged,
     orca.add_column("trips", "mode", choices)
 
     if trace_hh_id:
-        tracing.warn(__name__, "can't dump trips table because it doesn't exist")
+        logger.warn("can't dump trips table because it doesn't exist")
         # FIXME - commented out because trips table doesn't really exist
         # trace_columns = ['mode']
         # tracing.trace_df(orca.get_table('trips').to_frame(),

--- a/activitysim/defaults/models/mode.py
+++ b/activitysim/defaults/models/mode.py
@@ -48,7 +48,8 @@ def tour_mode_choice_spec(tour_mode_choice_spec_df,
                           tour_mode_choice_settings):
     return _mode_choice_spec(tour_mode_choice_spec_df,
                              tour_mode_choice_coeffs,
-                             tour_mode_choice_settings)
+                             tour_mode_choice_settings,
+                             trace_label='tour_mode_choice')
 
 
 @orca.injectable()

--- a/activitysim/defaults/models/mode.py
+++ b/activitysim/defaults/models/mode.py
@@ -135,7 +135,7 @@ def _mode_choice_simulate(tours,
     return choices
 
 
-def get_segment_and_unstack(spec, segment):
+def get_segment_and_unstack(omnibus_spec, segment):
     """
     This does what it says.  Take the spec, get the column from the spec for
     the given segment, and unstack.  It is assumed that the last column of
@@ -147,8 +147,11 @@ def get_segment_and_unstack(spec, segment):
     which original row - otherwise the unstack is incorrect (i.e. the index
     is not unique)
     """
-    return spec[segment].unstack().\
-        reset_index(level="Rowid", drop=True).fillna(0)
+    spec = omnibus_spec[segment].unstack().reset_index(level="Rowid", drop=True).fillna(0)
+
+    spec = spec.groupby(spec.index).sum()
+
+    return spec
 
 
 @orca.step()
@@ -199,10 +202,6 @@ def tour_mode_choice_simulate(tours_merged,
                      (len(segment.index), tour_type, ))
 
         # FIXME - check that destination is not null (patch_mandatory_tour_destination not run?)
-
-        # FIXME - no point in printing verbose dest_taz value_counts now that we have tracing?
-        # tracing.print_summary('tour_mode_choice_simulate %s dest_taz' % tour_type,
-        #                       segment[dest_key], value_counts=True)
 
         spec = get_segment_and_unstack(tour_mode_choice_spec, tour_type)
 

--- a/activitysim/defaults/models/non_mandatory_scheduling.py
+++ b/activitysim/defaults/models/non_mandatory_scheduling.py
@@ -43,8 +43,7 @@ def non_mandatory_scheduling(set_random_seed,
 
     tours = non_mandatory_tours_merged.to_frame()
 
-    tracing.info(__name__,
-                 "Running non_mandatory_scheduling with %d tours" % len(tours))
+    logger.info("Running non_mandatory_scheduling with %d tours" % len(tours))
 
     constants = get_model_constants(non_mandatory_scheduling_settings)
 

--- a/activitysim/defaults/models/non_mandatory_tour_frequency.py
+++ b/activitysim/defaults/models/non_mandatory_tour_frequency.py
@@ -67,8 +67,7 @@ def non_mandatory_tour_frequency(set_random_seed,
     # filter based on results of CDAP
     choosers = choosers[choosers.cdap_activity.isin(['M', 'N'])]
 
-    tracing.info(__name__,
-                 "Running non_mandatory_tour_frequency with %d persons" % len(choosers))
+    logger.info("Running non_mandatory_tour_frequency with %d persons" % len(choosers))
 
     constants = get_model_constants(non_mandatory_tour_frequency_settings)
 

--- a/activitysim/defaults/models/school_location.py
+++ b/activitysim/defaults/models/school_location.py
@@ -68,15 +68,19 @@ def school_location_simulate(set_random_seed,
         locals_d['segment'] = school_type
 
         choosers_segment = choosers[choosers["is_" + school_type]]
-
         tracing.info(__name__,
                      "school_type %s: %s persons" % (school_type, len(choosers_segment)))
+
+        # FIXME - no point in considering impossible alternatives
+        alternatives_segment = alternatives[alternatives[school_type] > 0]
+        tracing.info(__name__,
+                     "school_type %s: %s alternatives" % (school_type, len(alternatives_segment)))
 
         if len(choosers_segment.index) > 0:
 
             choices = asim.interaction_simulate(
                 choosers_segment,
-                alternatives,
+                alternatives_segment,
                 spec=school_location_spec[[school_type]],
                 skims=skims,
                 locals_d=locals_d,

--- a/activitysim/defaults/models/school_location.py
+++ b/activitysim/defaults/models/school_location.py
@@ -48,8 +48,7 @@ def school_location_simulate(set_random_seed,
 
     constants = get_model_constants(school_location_settings)
 
-    tracing.info(__name__,
-                 "Running school_location_simulate with %d persons" % len(choosers))
+    logger.info("Running school_location_simulate with %d persons" % len(choosers))
 
     # set the keys for this lookup - in this case there is a TAZ in the choosers
     # and a TAZ in the alternatives which get merged during interaction
@@ -68,13 +67,12 @@ def school_location_simulate(set_random_seed,
         locals_d['segment'] = school_type
 
         choosers_segment = choosers[choosers["is_" + school_type]]
-        tracing.info(__name__,
-                     "school_type %s: %s persons" % (school_type, len(choosers_segment)))
 
         # FIXME - no point in considering impossible alternatives
         alternatives_segment = alternatives[alternatives[school_type] > 0]
-        tracing.info(__name__,
-                     "school_type %s: %s alternatives" % (school_type, len(alternatives_segment)))
+
+        logger.info("school_type %s:  %s persons %s alternatives" %
+                    (school_type, len(choosers_segment), len(alternatives_segment)))
 
         if len(choosers_segment.index) > 0:
 
@@ -93,21 +91,9 @@ def school_location_simulate(set_random_seed,
 
     choices = pd.concat(choices_list)
 
-    # this fillna is necessary to avoid a downstream crash and might be a bit
-    # wrong logically.  The issue here is that there is a small but non-zero
-    # chance to choose a school trip even if not of the school type (because
-    # of -999 rather than outright removal of alternative availability). -
-    # this fills in the location for those uncommon circumstances,
-    # so at least it runs
-    if np.isnan(choices).any():
-        if trace_hh_id:
-            tracing.trace_nan_values(choices, 'school_location.choices')
-        logger.warn("Converting %s nan school_taz choices to -1" %
-                    (np.isnan(choices).sum(), len(choices.index)))
+    # We only chose school locations for the subset of persons who go to school
+    # so we backfill the empty choices with -1 to code as no school location
     choices = choices.reindex(persons_merged.index).fillna(-1)
-
-    tracing.info(__name__, "%s school_taz choices min: %s max: %s" %
-                 (len(choices.index), choices.min(), choices.max()))
 
     tracing.print_summary('school_taz', choices, describe=True)
 

--- a/activitysim/defaults/models/util/misc.py
+++ b/activitysim/defaults/models/util/misc.py
@@ -65,13 +65,13 @@ def get_logit_model_settings(model_settings):
         logit_type = model_settings.get('LOGIT_TYPE', 'MNL')
 
         if logit_type not in ['NL', 'MNL']:
-            tracing.error(__name__, "Unrecognized logit type '%s'" % logit_type)
+            logging.error("Unrecognized logit type '%s'" % logit_type)
             raise RuntimeError("Unrecognized logit type '%s'" % logit_type)
 
         if logit_type == 'NL':
             nests = model_settings.get('NESTS', None)
             if nests is None:
-                tracing.error(__name__, "No NEST found in model spec for NL model type")
+                logger.error("No NEST found in model spec for NL model type")
                 raise RuntimeError("No NEST found in model spec for NL model type")
 
     return nests

--- a/activitysim/defaults/models/util/mode.py
+++ b/activitysim/defaults/models/util/mode.py
@@ -46,11 +46,7 @@ def evaluate_expression_list(expressions, constants):
     # and must be evaluated in order
     for k, v in expressions.iteritems():
         # make sure it can be converted to a float
-
         result = float(eval(str(v), copy.copy(d), constants))
-
-        print "%s = %s = %s" % (k, v, result)
-
         d[k] = result
 
     return pd.Series(d)

--- a/activitysim/defaults/models/util/test/test_vectorize_tour_scheduling.py
+++ b/activitysim/defaults/models/util/test/test_vectorize_tour_scheduling.py
@@ -5,6 +5,8 @@
 import pytest
 import pandas as pd
 import numpy as np
+import orca
+
 import pandas.util.testing as pdt
 from ..vectorize_tour_scheduling import get_previous_tour_by_tourid, \
     vectorize_tour_scheduling
@@ -45,6 +47,8 @@ def test_vts():
     spec = pd.DataFrame({"Coefficient": [1.2]},
                         index=["income"])
     spec.index.name = "Expression"
+
+    orca.add_injectable("check_for_variability", True)
 
     choices = vectorize_tour_scheduling(tours, alts, spec)
 

--- a/activitysim/defaults/models/util/vectorize_tour_scheduling.py
+++ b/activitysim/defaults/models/util/vectorize_tour_scheduling.py
@@ -121,9 +121,8 @@ def vectorize_tour_scheduling(tours, alts, spec, constants={}, chunk_size=0, tra
         nth_tours.index.name = 'tour_id'
 
         if trace_label:
-            tracing.info(__name__,
-                         "vectorize_tour_scheduling %s running %d #%d tour choices" %
-                         (trace_label, len(nth_tours), i+1))
+            logger.info("vectorize_tour_scheduling %s running %d #%d tour choices" %
+                        (trace_label, len(nth_tours), i+1))
 
         # tour num can be set by the user, but if it isn't we set it here
         if "tour_num" not in nth_tours:

--- a/activitysim/defaults/models/util/vectorize_tour_scheduling.py
+++ b/activitysim/defaults/models/util/vectorize_tour_scheduling.py
@@ -133,7 +133,7 @@ def vectorize_tour_scheduling(tours, alts, spec, constants={}, chunk_size=0, tra
             previous_tour_by_personid,
             alts))
 
-        tour_trace_label = trace_label and "%s.tour_%s" % (trace_label, i)
+        tour_trace_label = tracing.extend_trace_label(trace_label, 'tour_%s' % i)
 
         nth_choices = asim.interaction_simulate(
             nth_tours,

--- a/activitysim/defaults/models/util/vectorize_tour_scheduling.py
+++ b/activitysim/defaults/models/util/vectorize_tour_scheduling.py
@@ -7,6 +7,7 @@ from activitysim import activitysim as asim
 
 import numpy as np
 import pandas as pd
+import orca
 
 from activitysim import tracing
 

--- a/activitysim/defaults/models/workplace_location.py
+++ b/activitysim/defaults/models/workplace_location.py
@@ -49,8 +49,7 @@ def workplace_location_simulate(set_random_seed,
 
     constants = get_model_constants(workplace_location_settings)
 
-    tracing.info(__name__,
-                 "Running workplace_location_simulate with %d persons" % len(choosers))
+    logger.info("Running workplace_location_simulate with %d persons" % len(choosers))
 
     # set the keys for this lookup - in this case there is a TAZ in the choosers
     # and a TAZ in the alternatives which get merged during interaction

--- a/activitysim/defaults/tables/households.py
+++ b/activitysim/defaults/tables/households.py
@@ -1,6 +1,8 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+import logging
+
 import numpy as np
 import orca
 import pandas as pd
@@ -8,6 +10,9 @@ import pandas as pd
 from activitysim import activitysim as asim
 from activitysim import tracing
 from activitysim.util import reindex
+
+logger = logging.getLogger(__name__)
+
 
 # not actually used, but helpful for dumping/documenting the contents of store
 # @orca.table(cache=True)
@@ -36,8 +41,8 @@ def households(set_random_seed, store, households_sample_size, trace_hh_id):
         # if tracing and we missed trace_hh in sample, but it is in full store
         if trace_hh_id and trace_hh_id not in df.index and trace_hh_id in df_full.index:
                 # replace first hh in sample with trace_hh
-                tracing.get_tracer().warn("replacing household %s with %s in household sample" %
-                                          (df.index[0], trace_hh_id))
+                logger.warn("replacing household %s with %s in household sample" %
+                            (df.index[0], trace_hh_id))
                 df_hh = tracing.slice_ids(df_full, trace_hh_id)
                 df = pd.concat([df_hh, df[1:]])
 
@@ -46,8 +51,7 @@ def households(set_random_seed, store, households_sample_size, trace_hh_id):
 
     if trace_hh_id:
         tracing.register_households(df, trace_hh_id)
-        tracing.trace_df(df, "households",
-                         warn_if_empty=True)
+        tracing.trace_df(df, "households", warn_if_empty=True)
 
     return df
 

--- a/activitysim/defaults/test/test_defaults.py
+++ b/activitysim/defaults/test/test_defaults.py
@@ -24,7 +24,7 @@ SKIP_FULL_RUN = False
 
 
 def inject_settings(configs_dir, households_sample_size, preload_3d_skims=None, chunk_size=None,
-                    trace_hh_id=None, trace_od=None):
+                    trace_hh_id=None, trace_od=None, check_for_variability=None):
 
     with open(os.path.join(configs_dir, 'settings.yaml')) as f:
         settings = yaml.load(f)
@@ -37,6 +37,8 @@ def inject_settings(configs_dir, households_sample_size, preload_3d_skims=None, 
             settings['trace_hh_id'] = trace_hh_id
         if trace_od is not None:
             settings['trace_od'] = trace_od
+        if check_for_variability is not None:
+            settings['check_for_variability'] = check_for_variability
 
     orca.add_injectable("settings", settings)
 
@@ -112,7 +114,7 @@ def test_mini_run(random_seed):
 
 def full_run(preload_3d_skims, chunk_size=0,
              households_sample_size=HOUSEHOLDS_SAMPLE_SIZE,
-             trace_hh_id=None, trace_od=None):
+             trace_hh_id=None, trace_od=None, check_for_variability=None):
 
     configs_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'example', 'configs')
     orca.add_injectable("configs_dir", configs_dir)
@@ -128,7 +130,8 @@ def full_run(preload_3d_skims, chunk_size=0,
                     preload_3d_skims=preload_3d_skims,
                     chunk_size=chunk_size,
                     trace_hh_id=trace_hh_id,
-                    trace_od=trace_od)
+                    trace_od=trace_od,
+                    check_for_variability=check_for_variability)
 
     orca.add_injectable("set_random_seed", set_random_seed)
 
@@ -175,7 +178,7 @@ def test_full_run():
     if SKIP_FULL_RUN:
         return
 
-    tour_count = full_run(preload_3d_skims=False)
+    tour_count = full_run(preload_3d_skims=False, check_for_variability=True)
     assert(tour_count == 230)
 
 

--- a/activitysim/nl.py
+++ b/activitysim/nl.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 import tracing
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -52,8 +53,8 @@ def report_bad_choices(bad_row_map, df, trace_label, msg, trace_choosers=None):
         else:
             hh_id = tracing.hh_id_for_chooser(idx, trace_choosers)
 
-        msg = "%s : %s in: %s = %s (hh_id = %s)" % (trace_label, msg, df.index.name, idx, hh_id)
-        logger.critical(msg)
+        row_msg = "%s : %s in: %s = %s (hh_id = %s)" % (trace_label, msg, df.index.name, idx, hh_id)
+        logger.critical(row_msg)
 
     raise RuntimeError(msg_with_count)
 
@@ -120,9 +121,8 @@ def utils_to_probs(utils, trace_label=None, exponentiated=False, allow_zero_prob
                            msg="infinite exponentiated utilities",
                            trace_choosers=trace_choosers)
 
-    np.divide(
-        utils_arr, arr_sum.reshape(len(utils_arr), 1),
-        out=utils_arr)
+    # if allow_zero_probs, this may cause a RuntimeWarning: invalid value encountered in divide
+    np.divide(utils_arr, arr_sum.reshape(len(utils_arr), 1), out=utils_arr)
 
     PROB_MIN = 0.0
     PROB_MAX = 1.0

--- a/activitysim/skim.py
+++ b/activitysim/skim.py
@@ -1,9 +1,10 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+import logging
+
 import numpy as np
 import pandas as pd
-import logging
 
 
 logger = logging.getLogger(__name__)

--- a/activitysim/tests/test_activitysim.py
+++ b/activitysim/tests/test_activitysim.py
@@ -8,6 +8,8 @@ import pandas as pd
 import pandas.util.testing as pdt
 import pytest
 
+import orca
+
 from .. import activitysim as asim
 
 
@@ -59,6 +61,9 @@ def test_eval_variables(spec, data):
 
 
 def test_simple_simulate(random_seed, data, spec):
+
+    orca.add_injectable("check_for_variability", False)
+
     choices = asim.simple_simulate(data, spec, None)
     expected = pd.Series([1, 1, 1], index=data.index)
     pdt.assert_series_equal(choices, expected)

--- a/activitysim/tests/test_nl.py
+++ b/activitysim/tests/test_nl.py
@@ -5,6 +5,8 @@ import os.path
 
 import numpy as np
 import pandas as pd
+import orca
+
 import pandas.util.testing as pdt
 import pytest
 
@@ -15,6 +17,15 @@ from .. import nl
 @pytest.fixture(scope='module')
 def data_dir():
     return os.path.join(os.path.dirname(__file__), 'data')
+
+
+def add_canonical_dirs():
+
+    configs_dir = os.path.join(os.path.dirname(__file__), 'configs')
+    orca.add_injectable("configs_dir", configs_dir)
+
+    output_dir = os.path.join(os.path.dirname(__file__), 'output')
+    orca.add_injectable("output_dir", output_dir)
 
 
 # this is lifted straight from urbansim's test_mnl.py
@@ -69,9 +80,15 @@ def test_utils_to_probs(utilities, test_data):
 
 def test_utils_to_probs_raises():
 
+    add_canonical_dirs()
+
     with pytest.raises(RuntimeError) as excinfo:
         nl.utils_to_probs(pd.DataFrame([[1, 2, np.inf, 3]]), trace_label=None)
-    assert "utility rows have infinite values" in str(excinfo.value)
+    assert "infinite exponentiated utilities" in str(excinfo.value)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        nl.utils_to_probs(pd.DataFrame([[-999, -999, -999, -999]]), trace_label=None)
+    assert "all probabilities are zero" in str(excinfo.value)
 
 
 def test_make_choices_only_one():

--- a/activitysim/tests/test_tracing.py
+++ b/activitysim/tests/test_tracing.py
@@ -29,27 +29,6 @@ def add_canonical_dirs():
     orca.add_injectable("output_dir", output_dir)
 
 
-def test_get_tracer(capsys):
-
-    output_dir = os.path.join(os.path.dirname(__file__), 'output')
-    orca.add_injectable("output_dir", output_dir)
-
-    tracing.get_tracer().warn("calling get_tracer before config_logger")
-
-    out, err = capsys.readouterr()
-
-    # don't consume output
-    print out
-
-    logfile_name = os.path.join(output_dir, 'asim.log')
-    with open(logfile_name, 'r') as f:
-        log = f.read()
-
-    assert "Initialized tracer activitysim.trace fileHandler" in log
-
-    close_handlers()
-
-
 def test_bad_custom_config_file(capsys):
 
     add_canonical_dirs()
@@ -68,11 +47,6 @@ def test_bad_custom_config_file(capsys):
     logger.info('log_info')
     logger.warn('log_warn1')
 
-    tracing.debug(__name__, 'test-debug-tracing')
-    tracing.info(__name__, 'test-info-tracing')
-    tracing.warn(__name__, 'test-warn-tracing')
-    tracing.error(__name__, 'test-error-tracing')
-
     out, err = capsys.readouterr()
 
     # don't consume output
@@ -81,11 +55,6 @@ def test_bad_custom_config_file(capsys):
     assert "could not find conf file" in out
     assert 'log_warn1' in out
     assert 'log_info' not in out
-
-    assert 'test-debug-tracing' not in out
-    assert 'test-info-tracing' not in out
-    assert 'test-warn-tracing' in out
-    assert 'test-error-tracing' in out
 
     close_handlers()
 

--- a/activitysim/tracing.py
+++ b/activitysim/tracing.py
@@ -23,6 +23,10 @@ LOGGING_CONF_FILE_NAME = 'logging.yaml'
 tracers = {}
 
 
+def check_for_variability():
+    return orca.get_injectable('check_for_variability')
+
+
 def extend_trace_label(trace_label, extension):
     if trace_label:
         trace_label = "%s.%s" % (trace_label, extension)
@@ -33,7 +37,8 @@ def print_elapsed_time(msg=None, t0=None):
     # FIXME - development debugging code to be removed
     t1 = time.time()
     if msg:
-        msg = "Time to execute %s : %s seconds" % (msg, t1 - (t0 or t1))
+        t = t1 - (t0 or t1)
+        msg = "Time to execute %s : %s seconds (%s minutes)" % (msg, round(t, 3), round(t/60.0))
         info(message=msg, log=True)
         print "_%s" % msg
     return t1

--- a/example/configs/logging.yaml
+++ b/example/configs/logging.yaml
@@ -19,13 +19,8 @@ logging:
       handlers: [console, logfile]
       propagate: false
 
-    activitysim.trace:
-      level: !!python/name:logging.DEBUG
-      handlers: [console, tracefile]
-      propagate: false
-
     orca:
-      level: !!python/name:logging.INFO
+      level: !!python/name:logging.WARN
       handlers: [console, logfile]
       propagate: false
 
@@ -37,14 +32,6 @@ logging:
       mode: w
       formatter: fileFormatter
       level: !!python/name:logging.NOTSET
-
-    tracefile:
-      class: logging.FileHandler
-      filename: !!python/object/apply:activitysim.tracing.log_file_path ['hhtrace.log']
-      mode: w
-      formatter: traceFormatter
-      #level: !!python/name:logging.NOTSET
-      level: !!python/name:logging.INFO
 
     console:
       class: logging.StreamHandler
@@ -65,7 +52,3 @@ logging:
       format: '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
       datefmt: '%d/%m/%Y %H:%M:%S'
 
-    traceFormatter:
-      class: !!python/name:logging.Formatter
-      format: '%(levelname)s - %(message)s'
-      datefmt: '%d/%m/%Y %H:%M:%S'

--- a/example/configs/settings.yaml
+++ b/example/configs/settings.yaml
@@ -19,6 +19,10 @@ chunk_size: 10000
 # if not specified, chunk_size setting value is used
 # hh_chunk_size: 5000
 
+# comment out or set false to disable variability check in simple_simulate and interaction_simulate
+check_for_variability: True
+
+
 # area_types less than this are considered urban
 urban_threshold: 4
 cbd_threshold: 2

--- a/example/configs/settings.yaml
+++ b/example/configs/settings.yaml
@@ -20,7 +20,7 @@ chunk_size: 10000
 # hh_chunk_size: 5000
 
 # comment out or set false to disable variability check in simple_simulate and interaction_simulate
-check_for_variability: True
+check_for_variability: False
 
 
 # area_types less than this are considered urban

--- a/example/configs/tour_departure_and_duration_nonmandatory.csv
+++ b/example/configs/tour_departure_and_duration_nonmandatory.csv
@@ -1,5 +1,6 @@
 Description,Expression,Coefficient
-Subsequent tour must start after previous tour ends,(start <= end_previous) & (tour_num > 1),-999
+# FIXME - Subsequent tour must start after previous tour ends,(start <= end_previous) & (tour_num > 1),-999
+Subsequent tour must start after previous tour ends,(start <= end_previous) & (tour_num > 1),-100
 Free-flow round trip auto time shift effects - duration,roundtrip_auto_time_to_work * duration,0.00474
 Shopping tour - departure shift effects,"(tour_type == ""shopping"") * start",0.06015
 Shopping tour - duration shift effects,"(tour_type == ""shopping"") * duration",0.1208

--- a/example/configs/tour_departure_and_duration_school.csv
+++ b/example/configs/tour_departure_and_duration_school.csv
@@ -7,7 +7,8 @@ University student departure shift effects,(ptype == 3) * start,0.28
 University student duration shift effects,(ptype == 3) * duration,0.2907
 Student driving age duration shift effects,(ptype == 7) * duration,0.03464
 All adults work full time- duration,(workers == hhsize) * duration,0.1093
-Subsequent tour must start after previous tour ends,(tour_num > 1) & (start < end_previous),-999
+# FIXME - Subsequent tour must start after previous tour ends,(tour_num > 1) & (start < end_previous),-999
+Subsequent tour must start after previous tour ends,(tour_num > 1) & (start < end_previous),-100
 First of 2+ school/univ. tours- departure,(tour_num == 1) * start,0.3002
 First of 2+ school/univ. tours- duration,(tour_num == 1) * duration,0.1593
 Subsequent of 2+ school/univ. tours- duration,(tour_num > 1) * duration,0.2338

--- a/example/configs/tour_departure_and_duration_work.csv
+++ b/example/configs/tour_departure_and_duration_work.csv
@@ -7,7 +7,8 @@ University student departure shift effects,(ptype == 3) * start,0.05747
 Household income departure shift effects,income_in_thousands * start,0.00021
 Destination in CBD departure shift effects,workplace_in_cbd * start,0.04717
 Destination in CBD duration shift effects,workplace_in_cbd * duration,0.08679
-Subsequent tour must start after previous tour ends,(start <= end_previous) & (tour_num == 2),-999
+# FIXME - Subsequent tour must start after previous tour ends,(start <= end_previous) & (tour_num == 2),-999
+Subsequent tour must start after previous tour ends,(start <= end_previous) & (tour_num == 2),-100
 First of 2+ work tours departure shift effects,(tour_num == 1) * start,0.3033
 First of 2+ work tours duration shift effects,(tour_num == 1) * duration,0.1861
 Subsequent 2+ work departure tours shift effects,(tour_num == 2) * start,0.5381

--- a/example/simulation.py
+++ b/example/simulation.py
@@ -7,13 +7,18 @@ import os
 
 from activitysim.tracing import print_elapsed_time
 
+def set_random_seed():
+    np.random.seed(0)
 
 def run_model(model_name):
     t0 = print_elapsed_time()
     orca.run([model_name])
     t0 = print_elapsed_time(model_name, t0)
-    
-orca.add_injectable("output_dir", 'output')
+
+
+# uncomment the line below to set random seed so that run results are reproducible
+# orca.add_injectable("set_random_seed", set_random_seed)
+
 tracing.config_logger()
 
 t0 = print_elapsed_time()

--- a/sandbox/configs/logging.yaml
+++ b/sandbox/configs/logging.yaml
@@ -19,13 +19,8 @@ logging:
       handlers: [console, logfile]
       propagate: false
 
-    activitysim.trace:
-      level: !!python/name:logging.DEBUG
-      handlers: [console, tracefile]
-      propagate: false
-
     orca:
-      level: !!python/name:logging.INFO
+      level: !!python/name:logging.WARN
       handlers: [console, logfile]
       propagate: false
 
@@ -39,20 +34,12 @@ logging:
       #level: !!python/name:logging.NOTSET
       level: !!python/name:logging.DEBUG
 
-    tracefile:
-      class: logging.FileHandler
-      filename: !!python/object/apply:activitysim.tracing.log_file_path ['hhtrace.log']
-      mode: w
-      formatter: traceFormatter
-      #level: !!python/name:logging.NOTSET
-      level: !!python/name:logging.DEBUG
-
     console:
       class: logging.StreamHandler
       stream: ext://sys.stdout
       formatter: simpleFormatter
       #level: !!python/name:logging.NOTSET
-      level: !!python/name:logging.INFO
+      level: !!python/name:logging.DEBUG
 
 
   formatters:
@@ -67,7 +54,3 @@ logging:
       format: '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
       datefmt: '%d/%m/%Y %H:%M:%S'
 
-    traceFormatter:
-      class: !!python/name:logging.Formatter
-      format: '%(levelname)s - %(message)s'
-      datefmt: '%d/%m/%Y %H:%M:%S'

--- a/sandbox/configs/settings.yaml
+++ b/sandbox/configs/settings.yaml
@@ -35,6 +35,9 @@ preload_3d_skims: True
 chunk_size: 10000
 hh_chunk_size: 5000
 
+# comment out or set false to disable
+check_for_variability: False
+
 # area_types less than this are considered urban
 urban_threshold: 4
 cbd_threshold: 2

--- a/sandbox/configs/settings.yaml
+++ b/sandbox/configs/settings.yaml
@@ -20,8 +20,12 @@ households_sample_size: 1000
 # trace_hh_id: 372947
 
 # 4 members
-trace_hh_id: 356174
+# trace_hh_id: 356174
 
+# zero prob for school location with unfiltered alternatives
+# trace_hh_id: 862924
+
+trace_hh_id:  238516
 
 # trace origin, destination in accessibility calculation
 # trace_od: [5, 11]

--- a/sandbox/configs/tour_departure_and_duration_nonmandatory.csv
+++ b/sandbox/configs/tour_departure_and_duration_nonmandatory.csv
@@ -1,5 +1,6 @@
 Description,Expression,Coefficient
-Subsequent tour must start after previous tour ends,(start <= end_previous) & (tour_num > 1),-999
+# FIXME - Subsequent tour must start after previous tour ends,(start <= end_previous) & (tour_num > 1),-999
+Subsequent tour must start after previous tour ends,(start <= end_previous) & (tour_num > 1),-100
 Free-flow round trip auto time shift effects - duration,roundtrip_auto_time_to_work * duration,0.00474
 Shopping tour - departure shift effects,"(tour_type == ""shopping"") * start",0.06015
 Shopping tour - duration shift effects,"(tour_type == ""shopping"") * duration",0.1208

--- a/sandbox/configs/tour_departure_and_duration_school.csv
+++ b/sandbox/configs/tour_departure_and_duration_school.csv
@@ -7,7 +7,8 @@ University student departure shift effects,(ptype == 3) * start,0.28
 University student duration shift effects,(ptype == 3) * duration,0.2907
 Student driving age duration shift effects,(ptype == 7) * duration,0.03464
 All adults work full time- duration,(workers == hhsize) * duration,0.1093
-Subsequent tour must start after previous tour ends,(tour_num > 1) & (start < end_previous),-999
+# FIXME - Subsequent tour must start after previous tour ends,(tour_num > 1) & (start < end_previous),-999
+Subsequent tour must start after previous tour ends,(tour_num > 1) & (start < end_previous),-100
 First of 2+ school/univ. tours- departure,(tour_num == 1) * start,0.3002
 First of 2+ school/univ. tours- duration,(tour_num == 1) * duration,0.1593
 Subsequent of 2+ school/univ. tours- duration,(tour_num > 1) * duration,0.2338

--- a/sandbox/configs/tour_departure_and_duration_work.csv
+++ b/sandbox/configs/tour_departure_and_duration_work.csv
@@ -7,7 +7,8 @@ University student departure shift effects,(ptype == 3) * start,0.05747
 Household income departure shift effects,income_in_thousands * start,0.00021
 Destination in CBD departure shift effects,workplace_in_cbd * start,0.04717
 Destination in CBD duration shift effects,workplace_in_cbd * duration,0.08679
-Subsequent tour must start after previous tour ends,(start <= end_previous) & (tour_num == 2),-999
+# FIXME - Subsequent tour must start after previous tour ends,(start <= end_previous) & (tour_num == 2),-999
+Subsequent tour must start after previous tour ends,(start <= end_previous) & (tour_num == 2),-100
 First of 2+ work tours departure shift effects,(tour_num == 1) * start,0.3033
 First of 2+ work tours duration shift effects,(tour_num == 1) * duration,0.1861
 Subsequent 2+ work departure tours shift effects,(tour_num == 2) * start,0.5381

--- a/sandbox/simulation.py
+++ b/sandbox/simulation.py
@@ -157,31 +157,31 @@ log_memory_info(logger, 'after stacked_skims load')
 
 from activitysim.defaults.models.util.mode import _mode_choice_spec
 
-spec = pd.DataFrame({
-    "Alternative": ["One", "One,Two"],
-    "Expression": ['1', '$expr.format(var="bar")'],
-    "Work": ['ivt', 'ivt_lr']
-}).set_index(["Expression"])
-
-coeffs = pd.DataFrame({
-    "Work": ['.7', 'ivt * .7 * COST']
-}, index=['ivt', 'ivt_lr'])
-
-settings = {
-    "CONSTANTS": {
-        "COST": 2.0
-    },
-    "VARIABLE_TEMPLATES": {
-        'expr': '@foo * {var}'
-    }
-}
-
-df = _mode_choice_spec(spec, coeffs, settings)
-
-
-print df
-
-
+# spec = pd.DataFrame({
+#     "Alternative": ["One", "One,Two"],
+#     "Expression": ['1', '$expr.format(var="bar")'],
+#     "Work": ['ivt', 'ivt_lr']
+# }).set_index(["Expression"])
+#
+# coeffs = pd.DataFrame({
+#     "Work": ['.7', 'ivt * .7 * COST']
+# }, index=['ivt', 'ivt_lr'])
+#
+# settings = {
+#     "CONSTANTS": {
+#         "COST": 2.0
+#     },
+#     "VARIABLE_TEMPLATES": {
+#         'expr': '@foo * {var}'
+#     }
+# }
+#
+# df = _mode_choice_spec(spec, coeffs, settings)
+#
+#
+# print df
+#
+#
 
 
 nests = orca.get_injectable('tour_mode_choice_settings')['NESTS']

--- a/sandbox/simulation.py
+++ b/sandbox/simulation.py
@@ -122,9 +122,9 @@ orca.add_injectable("set_random_seed", set_random_seed)
 #                 chunk_size = 50000,
 #                 hh_chunk_size = 50000)
 
-inject_settings(config='example',
+inject_settings(config='sandbox',
                 data='example',
-                households_sample_size=10000,
+                households_sample_size=100,
                 preload_3d_skims=True,
                 chunk_size = 0,
                 hh_chunk_size=0)
@@ -155,32 +155,40 @@ log_memory_info(logger, 'after stacked_skims load')
 # print "unique hh", p.household_id.unique()
 
 
-EMPTY_NEST = {'level': 0, 'product_of_coefficients': 1}
+from activitysim.defaults.models.util.mode import _mode_choice_spec
+
+spec = pd.DataFrame({
+    "Alternative": ["One", "One,Two"],
+    "Expression": ['1', '$expr.format(var="bar")'],
+    "Work": ['ivt', 'ivt_lr']
+}).set_index(["Expression"])
+
+coeffs = pd.DataFrame({
+    "Work": ['.7', 'ivt * .7 * COST']
+}, index=['ivt', 'ivt_lr'])
+
+settings = {
+    "CONSTANTS": {
+        "COST": 2.0
+    },
+    "VARIABLE_TEMPLATES": {
+        'expr': '@foo * {var}'
+    }
+}
+
+df = _mode_choice_spec(spec, coeffs, settings)
+
+
+print df
+
+
 
 
 nests = orca.get_injectable('tour_mode_choice_settings')['NESTS']
 
-# asim.trace_nests(nests, 'xxx')
-#
-# print "### each_nest"
-# for nest in nl.each_nest(nests):
-#
-#     print "%s %s name: %s parents %s" % ( "   " * nest.level, nest.type, nest.name, nest.ancestors)
-#
-# print "### each_nest_leaf"
-# for nest in nl.each_nest(nests, type='leaf'):
-#
-#     print "%s %s name: %s parents %s" % ( "   " * nest.level, nest.type, nest.name, nest.ancestors)
-
 t0 = print_elapsed_time()
 
 run_model('compute_accessibility')
-
-trace_hh_id = orca.get_injectable('trace_hh_id')
-if trace_hh_id:
-    tracing.trace_df(orca.get_table('persons_merged').to_frame(), "persons_merged",
-                     warn_if_empty=True)
-
 
 run_model('school_location_simulate')
 run_model('workplace_location_simulate')

--- a/sandbox/simulation.py
+++ b/sandbox/simulation.py
@@ -85,8 +85,8 @@ def print_table_schema(table_names):
            print "  %s: %s" % (col, df[col].dtype)
 
 
-def log_memory_info(logger, message):
-    logger.debug("%s %s" % (message, asim.memory_info()))
+def log_memory_info(message):
+    tracing.trace_logger().debug("%s %s" % (message, asim.memory_info()))
 
 
 def set_random_seed():
@@ -97,13 +97,14 @@ def run_model(model_name):
     t0 = print_elapsed_time()
     orca.run([model_name])
     t0 = print_elapsed_time(model_name, t0)
-    log_memory_info(logger, 'after %s' % model_name)
+    log_memory_info('after %s' % model_name)
 
 
 orca.add_injectable("output_dir", 'output')
 tracing.config_logger(os.path.join('configs', 'logging.yaml'))
 
-logger = logging.getLogger(__name__)
+logger = tracing.trace_logger()
+
 
 # pandas display options
 pd.options.display.max_columns = 500
@@ -122,21 +123,21 @@ orca.add_injectable("set_random_seed", set_random_seed)
 #                 chunk_size = 50000,
 #                 hh_chunk_size = 50000)
 
-inject_settings(config='sandbox',
-                data='example',
-                households_sample_size=100,
+inject_settings(config='example',
+                data='full',
+                households_sample_size=300000,
                 preload_3d_skims=True,
-                chunk_size = 0,
+                chunk_size = 100000,
                 hh_chunk_size=0)
 
 print_settings()
 
 
-log_memory_info(logger, 'startup')
+log_memory_info('startup')
 skims = orca.get_injectable('skims')
-log_memory_info(logger, 'after skim load')
+log_memory_info('after skim load')
 skims = orca.get_injectable('stacked_skims')
-log_memory_info(logger, 'after stacked_skims load')
+log_memory_info('after stacked_skims load')
 
 # df = orca.get_table('persons_merged').to_frame()
 # df = df[ ( df.hhsize == 6 )]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'orca >= 1.1',
         'pandas >= 0.18.0',
         'pyyaml >= 3.0',
-        'tables >= 3.1.0',
+        'tables >= 3.1.0, <3.3.0',
         'toolz >= 0.7',
         'zbox >= 1.2',
         'psutil >= 4.1'


### PR DESCRIPTION
Fixes #93 Remove NA alternatives before calculating probabilities
Fixes #94 exit when no alternatives available
Fixes #124 tour_mode_choice incorrectly assigns coefficients

Changes utility coefficients in school_location, work_location, and mandatory_scheduling expression files to prevent no-alternatives-available errors (for which I created issues 121 and 122) These workarounds that set utilities to -100 instead of -999 to prevent errors from being thrown.