### PR TITLE
toolz install failing with conda install toolz 0.8.2 - force 0.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 - conda update -q conda
 - conda info -a
 - |
-  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cytoolz numpy pandas pip pytables pyyaml
+  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cytoolz numpy pandas pip pytables pyyaml toolz=0.8.0
 - source activate test-environment
 - pip install orca openmatrix zbox
 - pip install pytest pytest-cov coveralls pep8 pytest-xdist

--- a/example/output/.gitignore
+++ b/example/output/.gitignore
@@ -1,2 +1,3 @@
 *.csv
 *.log
+*.prof


### PR DESCRIPTION
fix travis build for now by forcing toolz 0.8.0 until the condas dependencies/availabilities are straightened out