### PR TITLE
Skim wrappers

### DIFF
--- a/activitysim/activitysim.py
+++ b/activitysim/activitysim.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 from zbox import toolz as tz
 
-from .skim import Skims, Skims3D
+from .skim import SkimsWrapper, Skims3dWrapper
 from .nl import utils_to_probs, make_choices, interaction_dataset
 from .nl import report_bad_choices
 from .nl import each_nest
@@ -134,7 +134,7 @@ def eval_variables(exprs, df, locals_d=None):
 
 def add_skims(df, skims):
     """
-    Add the dataframe to the Skims object so that it can be dereferenced
+    Add the dataframe to the SkimsWrapper object so that it can be dereferenced
     using the parameters of the skims object.
 
     Parameters
@@ -142,7 +142,7 @@ def add_skims(df, skims):
     df : pandas.DataFrame
         Table to which to add skim data as new columns.
         `df` is modified in-place.
-    skims : Skims object
+    skims : SkimsWrapper object
         The skims object is used to contain multiple matrices of
         origin-destination impedances.  Make sure to also add it to the
         locals_d below in order to access it in expressions.  The *only* job
@@ -152,11 +152,11 @@ def add_skims(df, skims):
         the skims object is intended to be used.
     """
     if not isinstance(skims, list):
-        assert isinstance(skims, Skims) or isinstance(skims, Skims3D)
+        assert isinstance(skims, SkimsWrapper) or isinstance(skims, Skims3dWrapper)
         skims.set_df(df)
     else:
         for skim in skims:
-            assert isinstance(skim, Skims) or isinstance(skim, Skims3D)
+            assert isinstance(skim, SkimsWrapper) or isinstance(skim, Skims3dWrapper)
             skim.set_df(df)
 
 

--- a/activitysim/defaults/misc.py
+++ b/activitysim/defaults/misc.py
@@ -61,16 +61,8 @@ def store(data_dir, settings):
 
 
 @orca.injectable(cache=True)
-def preload_3d_skims(settings):
-    return bool(settings.get('preload_3d_skims', False))
-
-
-@orca.injectable(cache=True)
-def cache_skim_key_values(settings, preload_3d_skims):
-    if preload_3d_skims:
-        return settings['time_periods']['labels']
-    else:
-        return None
+def cache_skim_key_values(settings):
+    return settings['time_periods']['labels']
 
 
 @orca.injectable(cache=True)

--- a/activitysim/defaults/models/accessibility.py
+++ b/activitysim/defaults/models/accessibility.py
@@ -34,8 +34,8 @@ class AccessibilitySkims(object):
         whether to transpose the matrix before flattening. (i.e. act as a D-O instead of O-D skim)
     """
 
-    def __init__(self, skims, omx, length, transpose=False):
-        self.skims = skims
+    def __init__(self, skim_dict, omx, length, transpose=False):
+        self.skim_dict = skim_dict
         self.omx = omx
         self.length = length
         self.transpose = transpose
@@ -49,7 +49,7 @@ class AccessibilitySkims(object):
         skim['DISTANCE'] or skim[('SOVTOLL_TIME', 'MD')]
         """
         try:
-            data = self.skims.get_skim(key).data
+            data = self.skim_dict.get(key).data
         except KeyError:
             omx_key = '__'.join(key)
             logger.info("AccessibilitySkims loading %s from omx as %s" % (key, omx_key,))
@@ -82,7 +82,7 @@ def accessibility_settings(configs_dir):
 @orca.step()
 def compute_accessibility(settings, accessibility_spec,
                           accessibility_settings,
-                          skims, omx_file, land_use, trace_od):
+                          skim_dict, omx_file, land_use, trace_od):
 
     """
     Compute accessibility for each zone in land use file using expressions from accessibility_spec
@@ -130,8 +130,8 @@ def compute_accessibility(settings, accessibility_spec,
     locals_d = {
         'log': np.log,
         'exp': np.exp,
-        'skim_od': AccessibilitySkims(skims, omx_file, zone_count),
-        'skim_do': AccessibilitySkims(skims, omx_file, zone_count, transpose=True)
+        'skim_od': AccessibilitySkims(skim_dict, omx_file, zone_count),
+        'skim_do': AccessibilitySkims(skim_dict, omx_file, zone_count, transpose=True)
     }
     if constants is not None:
         locals_d.update(constants)

--- a/activitysim/defaults/models/destination.py
+++ b/activitysim/defaults/models/destination.py
@@ -30,7 +30,7 @@ def destination_choice_settings(configs_dir):
 @orca.step()
 def destination_choice(set_random_seed,
                        non_mandatory_tours_merged,
-                       skims,
+                       skim_dict,
                        destination_choice_spec,
                        destination_choice_settings,
                        destination_size_terms,
@@ -54,10 +54,10 @@ def destination_choice(set_random_seed,
         # register non_mandatory_tours so we can slice utilities
         tracing.register_tours(choosers, trace_hh_id)
 
-    # set the keys for this lookup - in this case there is a TAZ in the choosers
+    # create wrapper with keys for this lookup - in this case there is a TAZ in the choosers
     # and a TAZ in the alternatives which get merged during interaction
-    skims.set_keys("TAZ", "TAZ_r")
     # the skims will be available under the name "skims" for any @ expressions
+    skims = skim_dict.wrap("TAZ", "TAZ_r")
 
     locals_d = {
         'skims': skims

--- a/activitysim/defaults/models/school_location.py
+++ b/activitysim/defaults/models/school_location.py
@@ -33,7 +33,7 @@ def school_location_simulate(set_random_seed,
                              persons_merged,
                              school_location_spec,
                              school_location_settings,
-                             skims,
+                             skim_dict,
                              destination_size_terms,
                              chunk_size,
                              trace_hh_id):
@@ -50,10 +50,10 @@ def school_location_simulate(set_random_seed,
 
     logger.info("Running school_location_simulate with %d persons" % len(choosers))
 
-    # set the keys for this lookup - in this case there is a TAZ in the choosers
+    # create wrapper with keys for this lookup - in this case there is a TAZ in the choosers
     # and a TAZ in the alternatives which get merged during interaction
     # the skims will be available under the name "skims" for any @ expressions
-    skims.set_keys("TAZ", "TAZ_r")
+    skims = skim_dict.wrap("TAZ", "TAZ_r")
 
     locals_d = {
         'skims': skims

--- a/activitysim/defaults/models/workplace_location.py
+++ b/activitysim/defaults/models/workplace_location.py
@@ -30,7 +30,7 @@ def workplace_location_simulate(set_random_seed,
                                 persons_merged,
                                 workplace_location_spec,
                                 workplace_location_settings,
-                                skims,
+                                skim_dict,
                                 destination_size_terms,
                                 chunk_size,
                                 trace_hh_id):
@@ -51,10 +51,10 @@ def workplace_location_simulate(set_random_seed,
 
     logger.info("Running workplace_location_simulate with %d persons" % len(choosers))
 
-    # set the keys for this lookup - in this case there is a TAZ in the choosers
+    # create wrapper with keys for this lookup - in this case there is a TAZ in the choosers
     # and a TAZ in the alternatives which get merged during interaction
     # the skims will be available under the name "skims" for any @ expressions
-    skims.set_keys("TAZ", "TAZ_r")
+    skims = skim_dict.wrap("TAZ", "TAZ_r")
 
     locals_d = {
         'skims': skims

--- a/activitysim/defaults/tables/persons.py
+++ b/activitysim/defaults/tables/persons.py
@@ -274,7 +274,8 @@ def home_taz(households, persons):
 
 # this use the distance skims to compute the raw distance to work from home
 @orca.column("persons_workplace")
-def distance_to_work(persons, distance_skim):
+def distance_to_work(persons, skim_dict):
+    distance_skim = skim_dict.get('DIST')
     return pd.Series(distance_skim.get(persons.home_taz,
                                        persons.workplace_taz),
                      index=persons.index)
@@ -282,8 +283,8 @@ def distance_to_work(persons, distance_skim):
 
 # same deal as distance_to_work but to school
 @orca.column("persons_school")
-def distance_to_school(persons, distance_skim):
-    logger.debug("eval computed column persons_school.roundtrip_auto_time_to_school")
+def distance_to_school(persons, skim_dict):
+    distance_skim = skim_dict.get('DIST')
     return pd.Series(distance_skim.get(persons.home_taz,
                                        persons.school_taz),
                      index=persons.index)
@@ -292,7 +293,8 @@ def distance_to_school(persons, distance_skim):
 # this uses the free flow travel time in both directions
 # MTC TM1 was MD and MD since term is free flow roundtrip_auto_time_to_work
 @orca.column("persons_workplace")
-def roundtrip_auto_time_to_work(persons, sovmd_skim):
+def roundtrip_auto_time_to_work(persons, skim_dict):
+    sovmd_skim = skim_dict.get(('SOV_TIME', 'MD'))
     return pd.Series(sovmd_skim.get(persons.home_taz,
                                     persons.workplace_taz) +
                      sovmd_skim.get(persons.workplace_taz,
@@ -303,8 +305,8 @@ def roundtrip_auto_time_to_work(persons, sovmd_skim):
 # this uses the free flow travel time in both directions
 # MTC TM1 was MD and MD since term is free flow roundtrip_auto_time_to_school
 @orca.column("persons_school")
-def roundtrip_auto_time_to_school(persons, sovmd_skim):
-    logger.debug("eval computed column persons_school.roundtrip_auto_time_to_school")
+def roundtrip_auto_time_to_school(persons, skim_dict):
+    sovmd_skim = skim_dict.get(('SOV_TIME', 'MD'))
     return pd.Series(sovmd_skim.get(persons.home_taz,
                                     persons.school_taz) +
                      sovmd_skim.get(persons.school_taz,

--- a/activitysim/defaults/tables/skims.py
+++ b/activitysim/defaults/tables/skims.py
@@ -7,7 +7,7 @@ import logging
 import openmatrix as omx
 import orca
 
-from activitysim import skim
+from activitysim import skim as askim
 from activitysim import tracing
 
 logger = logging.getLogger(__name__)
@@ -26,38 +26,38 @@ def omx_file(data_dir, settings):
 
 
 @orca.injectable()
-def distance_skim(skims):
+def distance_skim(skim_dict):
     # want the Skim
-    return skims.get_skim('DISTANCE')
+    return skim_dict.get('DISTANCE')
 
 
 @orca.injectable()
-def sovam_skim(skims):
+def sovam_skim(skim_dict):
     # want the Skim
-    return skims.get_skim(('SOV_TIME', 'AM'))
+    return skim_dict.get(('SOV_TIME', 'AM'))
 
 
 @orca.injectable()
-def sovmd_skim(skims):
+def sovmd_skim(skim_dict):
     # want the Skim
-    return skims.get_skim(('SOV_TIME', 'MD'))
+    return skim_dict.get(('SOV_TIME', 'MD'))
 
 
 @orca.injectable()
-def sovpm_skim(skims):
+def sovpm_skim(skim_dict):
     # want the Skim
-    return skims.get_skim(('SOV_TIME', 'PM'))
+    return skim_dict.get(('SOV_TIME', 'PM'))
 
 
 @orca.injectable(cache=True)
-def skims(omx_file, preload_3d_skims, cache_skim_key_values):
+def skim_dict(omx_file, preload_3d_skims, cache_skim_key_values):
 
     logger.info("loading skims (preload_3d_skims: %s)" % preload_3d_skims)
 
-    skims = skim.Skims()
-    skims['DISTANCE'] = skim.Skim(omx_file['DIST'], offset=-1)
-    skims['DISTBIKE'] = skim.Skim(omx_file['DISTBIKE'], offset=-1)
-    skims['DISTWALK'] = skim.Skim(omx_file['DISTWALK'], offset=-1)
+    skim_dict = askim.SkimDict()
+    skim_dict.set('DISTANCE', askim.Skim(omx_file['DIST'], offset=-1))
+    skim_dict.set('DISTBIKE', askim.Skim(omx_file['DISTBIKE'], offset=-1))
+    skim_dict.set('DISTWALK', askim.Skim(omx_file['DISTWALK'], offset=-1))
 
     if preload_3d_skims:
         logger.info("skims injectable preloading preload_3d_skims")
@@ -68,18 +68,18 @@ def skims(omx_file, preload_3d_skims, cache_skim_key_values):
             # logger.debug("skims injectable preloading skim %s" % skim_name)
             key, sep, key2 = skim_name.partition('__')
             if key2 and key2 in cache_skim_key_values:
-                skims.set_3d(key, key2, skim.Skim(omx_file[skim_name], offset=-1))
+                skim_dict.set((key, key2), askim.Skim(omx_file[skim_name], offset=-1))
     else:
         # need to load these for the injectables above
-        skims.set_3d('SOV_TIME', 'AM', skim.Skim(omx_file['SOV_TIME__AM'], offset=-1))
-        skims.set_3d('SOV_TIME', 'PM', skim.Skim(omx_file['SOV_TIME__PM'], offset=-1))
-        skims.set_3d('SOV_TIME', 'MD', skim.Skim(omx_file['SOV_TIME__MD'], offset=-1))
+        skim_dict.set(('SOV_TIME', 'AM'), askim.Skim(omx_file['SOV_TIME__AM'], offset=-1))
+        skim_dict.set(('SOV_TIME', 'PM'), askim.Skim(omx_file['SOV_TIME__PM'], offset=-1))
+        skim_dict.set(('SOV_TIME', 'MD'), askim.Skim(omx_file['SOV_TIME__MD'], offset=-1))
 
-    return skims
+    return skim_dict
 
 
 @orca.injectable(cache=True)
-def stacked_skims(skims):
+def skim_stack(skim_dict):
 
-    logger.info("loading stacked_skims")
-    return skim.SkimStack(skims)
+    logger.info("loading skim_stack")
+    return askim.SkimStack(skim_dict)

--- a/activitysim/defaults/tables/skims.py
+++ b/activitysim/defaults/tables/skims.py
@@ -25,55 +25,24 @@ def omx_file(data_dir, settings):
     return omx.open_file(os.path.join(data_dir, settings["skims_file"]))
 
 
-@orca.injectable()
-def distance_skim(skim_dict):
-    # want the Skim
-    return skim_dict.get('DISTANCE')
-
-
-@orca.injectable()
-def sovam_skim(skim_dict):
-    # want the Skim
-    return skim_dict.get(('SOV_TIME', 'AM'))
-
-
-@orca.injectable()
-def sovmd_skim(skim_dict):
-    # want the Skim
-    return skim_dict.get(('SOV_TIME', 'MD'))
-
-
-@orca.injectable()
-def sovpm_skim(skim_dict):
-    # want the Skim
-    return skim_dict.get(('SOV_TIME', 'PM'))
-
-
 @orca.injectable(cache=True)
-def skim_dict(omx_file, preload_3d_skims, cache_skim_key_values):
+def skim_dict(omx_file, cache_skim_key_values):
 
-    logger.info("loading skims (preload_3d_skims: %s)" % preload_3d_skims)
+    logger.info("skims injectable loading skims")
 
     skim_dict = askim.SkimDict()
-    skim_dict.set('DISTANCE', askim.Skim(omx_file['DIST'], offset=-1))
-    skim_dict.set('DISTBIKE', askim.Skim(omx_file['DISTBIKE'], offset=-1))
-    skim_dict.set('DISTWALK', askim.Skim(omx_file['DISTWALK'], offset=-1))
-
-    if preload_3d_skims:
-        logger.info("skims injectable preloading preload_3d_skims")
-        # FIXME - assumes that the only types of key2 are time_periods
-        # there may be more time periods in the skim than are used by the model
-        skims_in_omx = omx_file.listMatrices()
-        for skim_name in skims_in_omx:
-            # logger.debug("skims injectable preloading skim %s" % skim_name)
-            key, sep, key2 = skim_name.partition('__')
-            if key2 and key2 in cache_skim_key_values:
+    skims_in_omx = omx_file.listMatrices()
+    for skim_name in skims_in_omx:
+        key, sep, key2 = skim_name.partition('__')
+        if not sep:
+            # no separator - this is a simple 2d skim - we load them all
+            skim_dict.set(key, askim.Skim(omx_file[skim_name], offset=-1))
+        else:
+            # there may be more time periods in the skim than are used by the model
+            # cache_skim_key_values is a list of time periods (frem settings) that are used
+            # FIXME - assumes that the only types of key2 are time_periods
+            if key2 in cache_skim_key_values:
                 skim_dict.set((key, key2), askim.Skim(omx_file[skim_name], offset=-1))
-    else:
-        # need to load these for the injectables above
-        skim_dict.set(('SOV_TIME', 'AM'), askim.Skim(omx_file['SOV_TIME__AM'], offset=-1))
-        skim_dict.set(('SOV_TIME', 'PM'), askim.Skim(omx_file['SOV_TIME__PM'], offset=-1))
-        skim_dict.set(('SOV_TIME', 'MD'), askim.Skim(omx_file['SOV_TIME__MD'], offset=-1))
 
     return skim_dict
 

--- a/activitysim/defaults/test/configs/workplace_location.csv
+++ b/activitysim/defaults/test/configs/workplace_location.csv
@@ -1,6 +1,6 @@
 Description,Expression,Alt
-"Distance, piecewise linear from 0 to 1 miles",@skims['DISTANCE'].clip(1),-0.8428
-"Distance, piecewise linear from 1 to 2 miles","@(skims['DISTANCE']-1).clip(0,1)",-0.3104
-"Distance, piecewise linear from 2 to 5 miles","@(skims['DISTANCE']-2).clip(0,3)",-0.3783
-"Distance, piecewise linear from 5 to 15 miles","@(skims['DISTANCE']-5).clip(0,10)",-0.1285
-"Distance, piecewise linear for 15+ miles",@(skims['DISTANCE']-15.0).clip(0),-0.0917
+"Distance, piecewise linear from 0 to 1 miles",@skims['DIST'].clip(1),-0.8428
+"Distance, piecewise linear from 1 to 2 miles","@(skims['DIST']-1).clip(0,1)",-0.3104
+"Distance, piecewise linear from 2 to 5 miles","@(skims['DIST']-2).clip(0,3)",-0.3783
+"Distance, piecewise linear from 5 to 15 miles","@(skims['DIST']-5).clip(0,10)",-0.1285
+"Distance, piecewise linear for 15+ miles",@(skims['DIST']-15.0).clip(0),-0.0917

--- a/activitysim/defaults/test/test_defaults.py
+++ b/activitysim/defaults/test/test_defaults.py
@@ -23,14 +23,12 @@ HOUSEHOLDS_SAMPLE_SIZE = 100
 SKIP_FULL_RUN = False
 
 
-def inject_settings(configs_dir, households_sample_size, preload_3d_skims=None, chunk_size=None,
+def inject_settings(configs_dir, households_sample_size, chunk_size=None,
                     trace_hh_id=None, trace_od=None, check_for_variability=None):
 
     with open(os.path.join(configs_dir, 'settings.yaml')) as f:
         settings = yaml.load(f)
         settings['households_sample_size'] = households_sample_size
-        if preload_3d_skims is not None:
-            settings['preload_3d_skims'] = preload_3d_skims
         if chunk_size is not None:
             settings['chunk_size'] = chunk_size
         if trace_hh_id is not None:
@@ -112,7 +110,7 @@ def test_mini_run(random_seed):
     orca.clear_cache()
 
 
-def full_run(preload_3d_skims, chunk_size=0,
+def full_run(chunk_size=0,
              households_sample_size=HOUSEHOLDS_SAMPLE_SIZE,
              trace_hh_id=None, trace_od=None, check_for_variability=None):
 
@@ -127,7 +125,6 @@ def full_run(preload_3d_skims, chunk_size=0,
 
     inject_settings(configs_dir,
                     households_sample_size=households_sample_size,
-                    preload_3d_skims=preload_3d_skims,
                     chunk_size=chunk_size,
                     trace_hh_id=trace_hh_id,
                     trace_od=trace_od,
@@ -178,17 +175,7 @@ def test_full_run():
     if SKIP_FULL_RUN:
         return
 
-    tour_count = full_run(preload_3d_skims=False, check_for_variability=True)
-    assert(tour_count == 230)
-
-
-def test_full_run_with_preload_skims():
-
-    if SKIP_FULL_RUN:
-        return
-
-    tour_count = full_run(preload_3d_skims=True)
-
+    tour_count = full_run(check_for_variability=True)
     assert(tour_count == 230)
 
 
@@ -197,7 +184,7 @@ def test_full_run_with_chunks():
     if SKIP_FULL_RUN:
         return
 
-    tour_count = full_run(preload_3d_skims=True, chunk_size=10)
+    tour_count = full_run(chunk_size=10)
 
     # different sampling causes slightly different results
     assert(tour_count == 219)
@@ -222,7 +209,7 @@ def test_full_run_with_hh_trace():
     HH_ID = 961042
     OD = [5, 11]
 
-    tour_count = full_run(preload_3d_skims=True, trace_hh_id=HH_ID, trace_od=OD)
+    tour_count = full_run(trace_hh_id=HH_ID, trace_od=OD)
 
     assert(tour_count == 230)
 

--- a/activitysim/defaults/test/test_misc.py
+++ b/activitysim/defaults/test/test_misc.py
@@ -69,4 +69,3 @@ def test_misc():
     # default values if not specified in settings
     assert orca.get_injectable("hh_chunk_size") == 0
     assert orca.get_injectable("chunk_size") == 0
-    assert orca.get_injectable("preload_3d_skims") is False

--- a/activitysim/tests/test_skim.py
+++ b/activitysim/tests/test_skim.py
@@ -50,14 +50,15 @@ def test_skim_nans(data):
 
 def test_skims(data):
 
-    skims = skim.Skims()
-    skims.set_keys("taz_l", "taz_r")
+    skim_dict = skim.SkimDict()
 
     sk = skim.Skim(data)
     sk2 = skim.Skim(data)
 
-    skims['AM'] = sk
-    skims['PM'] = sk2
+    skim_dict.set('AM', sk)
+    skim_dict.set('PM', sk2)
+
+    skims = skim_dict.wrap("taz_l", "taz_r")
 
     df = pd.DataFrame({
         "taz_l": [1, 9, 4],
@@ -85,18 +86,17 @@ def test_skims(data):
 
 def test_3dskims(data):
 
-    skims = skim.Skims()
-    skims.set_keys("taz_l", "taz_r")
+    skim_dict = skim.SkimDict()
 
     sk = skim.Skim(data)
     sk2 = skim.Skim(data)
 
-    skims.set_3d("SOV", "AM", sk)
-    skims.set_3d("SOV", "PM", sk2)
+    skim_dict.set(("SOV", "AM"), sk)
+    skim_dict.set(("SOV", "PM"), sk2)
 
-    stack = skim.SkimStack(skims)
+    stack = skim.SkimStack(skim_dict)
 
-    skims3d = skim.Skims3D(stack=stack, left_key="taz_l", right_key="taz_r", skim_key="period")
+    skims3d = stack.wrap(left_key="taz_l", right_key="taz_r", skim_key="period")
 
     df = pd.DataFrame({
         "taz_l": [1, 9, 4],

--- a/docs/dataschema.rst
+++ b/docs/dataschema.rst
@@ -545,6 +545,7 @@ Skims
 
 The skims class defines orca injectables to access the skim matrices.  The skims class reads the
 skims from the omx_file on disk.  The injectables and omx_file for the example are listed below.
+The skimss are float64 matrix.
 
 Injectables
 ~~~~~~~~~~~
@@ -552,17 +553,10 @@ Injectables
 +----------------------------------------------------+-----------------+----------------------------------------------------+------------+
 |                                              Table |            Type |                                            Creator |    Virtual |
 +====================================================+=================+====================================================+============+
-|                                      distance_skim |  float64 matrix |          skims.py -> skims['DISTANCE'] -> omx_file |          T |
+|                                          skim_dict |        SkimDict |                  skims.py -> skim_dict -> omx_file |          T |
 +----------------------------------------------------+-----------------+----------------------------------------------------+------------+
-|                                         sovam_skim |  float64 matrix |   skims.py -> skims[('SOV_TIME','AM')] -> omx_file |          T |
+|                                         skim_stack |       SkimStack |    skims.py -> skim_stack -> skim_dict -> omx_file |          T |
 +----------------------------------------------------+-----------------+----------------------------------------------------+------------+
-|                                         sovmd_skim |  float64 matrix |   skims.py -> skims[('SOV_TIME','MD')] -> omx_file |          T |
-+----------------------------------------------------+-----------------+----------------------------------------------------+------------+
-|                                         sovpm_skim |  float64 matrix |   skims.py -> skims[('SOV_TIME','PM')] -> omx_file |          T |
-+----------------------------------------------------+-----------------+----------------------------------------------------+------------+
-|                                              skims |  float64 matrix |                      skims.py -> skims -> omx_file |          T |
-+----------------------------------------------------+-----------------+----------------------------------------------------+------------+
-
 
 omx_file
 ~~~~~~~~

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -601,18 +601,18 @@ orca table named ``mandatory_tours``.
   
 .. _Skims_3D :
 
-Skims3D
-~~~~~~~
+Skims3dWrapper
+~~~~~~~~~~~~~~
 
-The mode choice model uses the Skims3D class in addition to the skims (2D) class.  The Skims3D class represents 
+The mode choice model uses the Skims3dWrapper class in addition to the skims (2D) class.  The Skims3dWrapper class represents
 a collection of skims with a third dimension, which in this case in time period.  Setting up the 3D index for 
-Skims3D is done as follows:
+Skims3dWrapper is done as follows:
 
 ::
 
   #setup two indexes - tour inbound skims and tour outbound skims
-  in_skims = askim.Skims3D(stack=stack, left_key=orig_key, right_key=dest_key, skim_key="in_period", offset=-1)
-  out_skims = askim.Skims3D(stack=stack, left_key=dest_key, right_key=orig_key, skim_key="out_period", offset=-1)
+  in_skims = askim.Skims3dWrapper(stack=stack, left_key=orig_key, right_key=dest_key, skim_key="in_period", offset=-1)
+  out_skims = askim.Skims3dWrapper(stack=stack, left_key=dest_key, right_key=orig_key, skim_key="out_period", offset=-1)
     
   #where:
   stack = askim.SkimStack(skims)       #build 3D skim object from 2D skims table object

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -132,7 +132,7 @@ function.  This function is called in the orca step ``tour_mode_choice_simulate`
 the example via ``orca.run(["tour_mode_choice_simulate"])``.
 
 Core Table: ``tours`` | Result Field: ``mode`` | Skims Keys: ``TAZ,destination`` | 
-Skims3D in_skims Keys: ``TAZ,destination,in_period`` | Skims3D out_skims Keys: ``destination,TAZ,out_period``
+Skims3dWrapper in_skims Keys: ``TAZ,destination,in_period`` | Skims3dWrapper out_skims Keys: ``destination,TAZ,out_period``
 
 Trip
 ~~~~
@@ -143,7 +143,7 @@ function.  This function is called in the orca step ``trip_mode_choice_simulate`
 the example via ``orca.run(["trip_mode_choice_simulate"])``.
 
 Core Table: ``trips`` | Result Field: ``mode`` | Skims Keys: ``TAZ,destination``
-Skims3D in_skims Keys: ``TAZ,destination,in_period`` | Skims3D out_skims Keys: ``destination,TAZ,out_period``
+Skims3dWrapper in_skims Keys: ``TAZ,destination,in_period`` | Skims3dWrapper out_skims Keys: ``destination,TAZ,out_period``
 
 
 API

--- a/example/configs/destination_choice.csv
+++ b/example/configs/destination_choice.csv
@@ -1,10 +1,10 @@
 Description,Expression,university,highschool,gradeschool,escortkids,escortnokids,shopping,eatout,othmaint,social,othdiscr,workbased
 # Sample of alternatives correction factor,"min(dcSoaCorrections,60)",1,1,1,1,1,1,1,1,1,1,1
-"Distance, piecewise linear from 0 to 1 miles",@skims['DISTANCE'].clip(1),-3.2451,-0.9523,-1.6419,-0.1499,-0.1499,0,-0.5609,0,-0.7841,-0.1677,-0.7926
-"Distance, piecewise linear from 1 to 2 miles","@(skims['DISTANCE']-1).clip(0,1)",-2.7011,-0.57,-0.57,-0.1499,-0.1499,0,-0.5609,0,-0.7841,-0.1677,-0.7926
-"Distance, piecewise linear from 2 to 5 miles","@(skims['DISTANCE']-2).clip(0,3)",-0.5707,-0.57,-0.57,-0.8671,-0.8671,-0.5655,-0.3192,-0.6055,-0.3485,-0.4955,-0.5197
-"Distance, piecewise linear from 5 to 15 miles","@(skims['DISTANCE']-5).clip(0,10)",-0.5002,-0.193,-0.2031,-0.2137,-0.2137,-0.1832,-0.1238,-0.1093,-0.1306,-0.1193,-0.2045
-"Distance, piecewise linear for 15+ miles",@(skims['DISTANCE']-15.0).clip(0),-0.073,-0.1882,-0.046,-0.2137,-0.2137,-0.1832,-0.1238,-0.1093,-0.1306,-0.1193,-0.2045
+"Distance, piecewise linear from 0 to 1 miles",@skims['DIST'].clip(1),-3.2451,-0.9523,-1.6419,-0.1499,-0.1499,0,-0.5609,0,-0.7841,-0.1677,-0.7926
+"Distance, piecewise linear from 1 to 2 miles","@(skims['DIST']-1).clip(0,1)",-2.7011,-0.57,-0.57,-0.1499,-0.1499,0,-0.5609,0,-0.7841,-0.1677,-0.7926
+"Distance, piecewise linear from 2 to 5 miles","@(skims['DIST']-2).clip(0,3)",-0.5707,-0.57,-0.57,-0.8671,-0.8671,-0.5655,-0.3192,-0.6055,-0.3485,-0.4955,-0.5197
+"Distance, piecewise linear from 5 to 15 miles","@(skims['DIST']-5).clip(0,10)",-0.5002,-0.193,-0.2031,-0.2137,-0.2137,-0.1832,-0.1238,-0.1093,-0.1306,-0.1193,-0.2045
+"Distance, piecewise linear for 15+ miles",@(skims['DIST']-15.0).clip(0),-0.073,-0.1882,-0.046,-0.2137,-0.2137,-0.1832,-0.1238,-0.1093,-0.1306,-0.1193,-0.2045
 # Mode choice logsum,mcLogsum,0.5358,0.5358,0.5358,0.6755,0.6755,0.6755,0.6755,0.6755,0.6755,0.6755,0.5136
 Size variable,@df[segment].apply(np.log1p),1,1,1,1,1,1,1,1,1,1,1
 No attractions,@df[segment]==0,-999,-999,-999,-999,-999,-999,-999,-999,-999,-999,-999

--- a/example/configs/school_location.csv
+++ b/example/configs/school_location.csv
@@ -1,9 +1,9 @@
 Description,Expression,university,highschool,gradeschool
-"Distance, piecewise linear from 0 to 1 miles",@skims['DISTANCE'].clip(1),-3.2451,-0.9523,-1.6419
-"Distance, piecewise linear from 1 to 2 miles","@(skims['DISTANCE']-1).clip(0,1)",-2.7011,-0.5700,-0.5700
-"Distance, piecewise linear from 2 to 5 miles","@(skims['DISTANCE']-2).clip(0,3)",-0.5707,-0.5700,-0.5700
-"Distance, piecewise linear from 5 to 15 miles","@(skims['DISTANCE']-5).clip(0,10)",-0.5002,-0.1930,-0.2031
-"Distance, piecewise linear for 15+ miles",@(skims['DISTANCE']-15.0).clip(0),-0.0730,-0.1882,-0.0460
+"Distance, piecewise linear from 0 to 1 miles",@skims['DIST'].clip(1),-3.2451,-0.9523,-1.6419
+"Distance, piecewise linear from 1 to 2 miles","@(skims['DIST']-1).clip(0,1)",-2.7011,-0.5700,-0.5700
+"Distance, piecewise linear from 2 to 5 miles","@(skims['DIST']-2).clip(0,3)",-0.5707,-0.5700,-0.5700
+"Distance, piecewise linear from 5 to 15 miles","@(skims['DIST']-5).clip(0,10)",-0.5002,-0.1930,-0.2031
+"Distance, piecewise linear for 15+ miles",@(skims['DIST']-15.0).clip(0),-0.0730,-0.1882,-0.0460
 Mode choice logsum,mode_choice_logsums,0.5358,0.5358,0.5358
 Size variable,@df[segment].apply(np.log1p),1.0000,1.0000,1.0000
 No attractions,@df[segment]==0,-999.0000,-999.0000,-999.0000

--- a/example/configs/settings.yaml
+++ b/example/configs/settings.yaml
@@ -12,7 +12,6 @@ trace_hh_id: 961042
 trace_od: [5, 11]
 
 #internal settings 
-preload_3d_skims: True
 chunk_size: 10000
 # chunk size for models that must process all data for a household in he same chunk (e.g. cdap)
 # if not specified, chunk_size setting value is used

--- a/example/configs/tour_mode_choice.yaml
+++ b/example/configs/tour_mode_choice.yaml
@@ -79,7 +79,7 @@ VARIABLE_TEMPLATES:
                        *costPerMile)"
     AUTO_ACCESS_RATIO_EXPR: "@(out_skims['{sk1}']/100+
                                in_skims['{sk2}']/100)/
-                               (skims['DISTANCE']*2)"
+                               (skims['DIST']*2)"
 
 
 CONSTANTS:

--- a/example/configs/trip_mode_choice.yaml
+++ b/example/configs/trip_mode_choice.yaml
@@ -87,11 +87,11 @@ VARIABLE_TEMPLATES:
                        *costPerMile)"
     AUTO_ACCESS_RATIO_EXPR: "@(out_skims['{sk1}']/100+
                                in_skims['{sk2}']/100)/
-                               (skims['DISTANCE']*2)"
+                               (skims['DIST']*2)"
     OUT_AUTO_ACCESS_RATIO_EXPR: "@out_skims['{sk}']/100/
-                                   skims['DISTANCE']"
+                                   skims['DIST']"
     IN_AUTO_ACCESS_RATIO_EXPR: "@in_skims['{sk}']/100/
-                                   skims['DISTANCE']"
+                                   skims['DIST']"
 
 
 CONSTANTS:

--- a/example/configs/workplace_location.csv
+++ b/example/configs/workplace_location.csv
@@ -1,11 +1,11 @@
 Description,Expression,Alt
-"Distance, piecewise linear from 0 to 1 miles",@skims['DISTANCE'].clip(1),-0.8428
-"Distance, piecewise linear from 1 to 2 miles","@(skims['DISTANCE']-1).clip(0,1)",-0.3104
-"Distance, piecewise linear from 2 to 5 miles","@(skims['DISTANCE']-2).clip(0,3)",-0.3783
-"Distance, piecewise linear from 5 to 15 miles","@(skims['DISTANCE']-5).clip(0,10)",-0.1285
-"Distance, piecewise linear for 15+ miles",@(skims['DISTANCE']-15.0).clip(0),-0.0917
-"Distance 0 to 5 mi, high and very high income",@(df.income_segment>=3)*skims['DISTANCE'].clip(upper=5),0.15
-"Distance 5+ mi, high and very high income",@(df.income_segment>=3)*(skims['DISTANCE']-5).clip(0),0.02
+"Distance, piecewise linear from 0 to 1 miles",@skims['DIST'].clip(1),-0.8428
+"Distance, piecewise linear from 1 to 2 miles","@(skims['DIST']-1).clip(0,1)",-0.3104
+"Distance, piecewise linear from 2 to 5 miles","@(skims['DIST']-2).clip(0,3)",-0.3783
+"Distance, piecewise linear from 5 to 15 miles","@(skims['DIST']-5).clip(0,10)",-0.1285
+"Distance, piecewise linear for 15+ miles",@(skims['DIST']-15.0).clip(0),-0.0917
+"Distance 0 to 5 mi, high and very high income",@(df.income_segment>=3)*skims['DIST'].clip(upper=5),0.15
+"Distance 5+ mi, high and very high income",@(df.income_segment>=3)*(skims['DIST']-5).clip(0),0.02
 "Size variable full-time worker, low income","@(df.income_segment==1)*df['work, low'].apply(np.log1p)",1
 "Size variable full-time worker, medium income","@(df.income_segment==2)*df['work, med'].apply(np.log1p)",1
 "Size variable full-time worker, high income","@(df.income_segment==3)*df['work, high'].apply(np.log1p)",1


### PR DESCRIPTION
Factor the functionality for vectorized retrieval of skim values into lightweight wrappers distinct from the underlying skim storage. This separates the transient state used by the wrappers (df and column labels) from the underlying skim data storage. Also cleared up naming of variables and datatypes where the term 'skim' and 'skims' were used a bewildering number of times in different ways.